### PR TITLE
Modernize settings page

### DIFF
--- a/CelestiaWinUI/MainWindow.xaml.cpp
+++ b/CelestiaWinUI/MainWindow.xaml.cpp
@@ -1651,6 +1651,8 @@ namespace winrt::CelestiaWinUI::implementation
         window.SystemBackdrop(Media::MicaBackdrop());
         window.Title(LocalizationHelper::Localize(L"Settings", L""));
         window.Content(userControl);
+        window.ExtendsContentIntoTitleBar(true);
+        window.SetTitleBar(userControl.TitleBarElement());
         WindowHelper::SetWindowIcon(window);
         WindowHelper::SetWindowTheme(window);
         WindowHelper::SetWindowFlowDirection(window);

--- a/CelestiaWinUI/MainWindow.xaml.cpp
+++ b/CelestiaWinUI/MainWindow.xaml.cpp
@@ -1654,7 +1654,7 @@ namespace winrt::CelestiaWinUI::implementation
         WindowHelper::SetWindowIcon(window);
         WindowHelper::SetWindowTheme(window);
         WindowHelper::SetWindowFlowDirection(window);
-        WindowHelper::ResizeWindow(window, 400, 600);
+        WindowHelper::ResizeWindow(window, 900, 700);
         WindowHelper::TrackWindow(window, id);
         window.Activate();
     }

--- a/CelestiaWinUI/SettingCommonUserControl.idl
+++ b/CelestiaWinUI/SettingCommonUserControl.idl
@@ -25,16 +25,32 @@ namespace CelestiaWinUI
         Microsoft.UI.Xaml.DataTemplate Toggle;
         Microsoft.UI.Xaml.DataTemplate Selection;
         Microsoft.UI.Xaml.DataTemplate Slider;
-        Microsoft.UI.Xaml.DataTemplate Header;
         Microsoft.UI.Xaml.DataTemplate DataDirectory;
         Microsoft.UI.Xaml.DataTemplate ConfigFile;
+    }
+
+    [default_interface]
+    runtimeclass SettingItemGroup : Microsoft.UI.Xaml.Data.INotifyPropertyChanged
+    {
+        SettingItemGroup(String title, String description, Boolean headerVisible, Boolean descriptionVisible);
+        String Title{ get; };
+        String Description{ get; };
+        Boolean HeaderVisible;
+        Boolean DescriptionVisible{ get; };
+        Windows.Foundation.Collections.IObservableVector<Object> Items{ get; };
+    }
+
+    [default_interface]
+    runtimeclass SettingGroupSeparator
+    {
+        SettingGroupSeparator();
     }
 
     [default_interface]
     runtimeclass SettingCommonUserControl : Microsoft.UI.Xaml.Controls.UserControl
     {
         SettingCommonUserControl(Windows.Foundation.Collections.IObservableVector<Object> settingItems, Boolean showRestartHint, SettingParameter parameter);
-        Windows.Foundation.Collections.IObservableVector<Object> Items{ get; };
+        Windows.Foundation.Collections.IObservableVector<SettingItemGroup> Groups{ get; };
         Boolean ShowRestartHint{ get; };
     }
 }

--- a/CelestiaWinUI/SettingCommonUserControl.idl
+++ b/CelestiaWinUI/SettingCommonUserControl.idl
@@ -25,19 +25,22 @@ namespace CelestiaWinUI
         Microsoft.UI.Xaml.DataTemplate Toggle;
         Microsoft.UI.Xaml.DataTemplate Selection;
         Microsoft.UI.Xaml.DataTemplate Slider;
+        Microsoft.UI.Xaml.DataTemplate Header;
+        Microsoft.UI.Xaml.DataTemplate Separator;
         Microsoft.UI.Xaml.DataTemplate DataDirectory;
         Microsoft.UI.Xaml.DataTemplate ConfigFile;
     }
 
     [default_interface]
-    runtimeclass SettingItemGroup : Microsoft.UI.Xaml.Data.INotifyPropertyChanged
+    runtimeclass SettingListItem : Microsoft.UI.Xaml.Data.INotifyPropertyChanged
     {
-        SettingItemGroup(String title, String description, Boolean headerVisible, Boolean descriptionVisible);
-        String Title{ get; };
-        String Description{ get; };
-        Boolean HeaderVisible;
-        Boolean DescriptionVisible{ get; };
-        Windows.Foundation.Collections.IObservableVector<Object> Items{ get; };
+        SettingListItem(Object item, Boolean isSetting);
+        Object Item{ get; };
+        Microsoft.UI.Xaml.Visibility SettingVisibility{ get; };
+        Microsoft.UI.Xaml.Thickness BorderThickness{ get; };
+        Microsoft.UI.Xaml.CornerRadius CornerRadius{ get; };
+        Microsoft.UI.Xaml.Thickness Margin{ get; };
+        Microsoft.UI.Xaml.Thickness ContentMargin{ get; };
     }
 
     [default_interface]
@@ -50,7 +53,7 @@ namespace CelestiaWinUI
     runtimeclass SettingCommonUserControl : Microsoft.UI.Xaml.Controls.UserControl
     {
         SettingCommonUserControl(Windows.Foundation.Collections.IObservableVector<Object> settingItems, Boolean showRestartHint, SettingParameter parameter);
-        Windows.Foundation.Collections.IObservableVector<SettingItemGroup> Groups{ get; };
+        Windows.Foundation.Collections.IObservableVector<SettingListItem> Rows{ get; };
         Boolean ShowRestartHint{ get; };
     }
 }

--- a/CelestiaWinUI/SettingCommonUserControl.xaml
+++ b/CelestiaWinUI/SettingCommonUserControl.xaml
@@ -187,7 +187,7 @@
             RelativePanel.AlignLeftWithPanel="True"
             RelativePanel.AlignRightWithPanel="True"
             RelativePanel.AlignTopWithPanel="True"/>
-        <ScrollViewer
+        <ScrollView
             RelativePanel.AlignBottomWithPanel="True"
             RelativePanel.AlignLeftWithPanel="True"
             RelativePanel.AlignRightWithPanel="True"
@@ -207,7 +207,7 @@
                     </Style>
                 </ItemsControl.ItemContainerStyle>
             </ItemsControl>
-        </ScrollViewer>
+        </ScrollView>
 
         <VisualStateManager.VisualStateGroups>
             <VisualStateGroup>

--- a/CelestiaWinUI/SettingCommonUserControl.xaml
+++ b/CelestiaWinUI/SettingCommonUserControl.xaml
@@ -10,9 +10,8 @@
 
     <UserControl.Resources>
         <Style x:Key="SettingsCardStyle" TargetType="Border">
+            <Setter Property="Background" Value="{ThemeResource CardBackgroundFillColorDefaultBrush}"/>
             <Setter Property="BorderBrush" Value="{ThemeResource CardStrokeColorDefaultBrush}"/>
-            <Setter Property="BorderThickness" Value="0,0,0,1"/>
-            <Setter Property="Padding" Value="16"/>
         </Style>
 
         <Style x:Key="SettingTitleStyle" TargetType="TextBlock">
@@ -31,8 +30,7 @@
         </Style>
 
         <DataTemplate x:Key="ToggleItemTemplate" x:DataType="app:SettingBooleanItem">
-            <Border Style="{StaticResource SettingsCardStyle}">
-                <Grid ColumnSpacing="24">
+            <Grid ColumnSpacing="24">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*"/>
                         <ColumnDefinition Width="Auto"/>
@@ -49,13 +47,11 @@
                         OnContent=""
                         AutomationProperties.Name="{x:Bind Title, Mode=OneTime}"
                         IsOn="{x:Bind IsEnabled, Mode=TwoWay}"/>
-                </Grid>
-            </Border>
+            </Grid>
         </DataTemplate>
 
         <DataTemplate x:Key="SliderItemTemplate" x:DataType="app:SettingDoubleItem">
-            <Border Style="{StaticResource SettingsCardStyle}">
-                <Grid ColumnSpacing="24">
+            <Grid ColumnSpacing="24">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*"/>
                         <ColumnDefinition Width="Auto"/>
@@ -75,13 +71,11 @@
                         Value="{x:Bind Value, Mode=TwoWay}"
                         AutomationProperties.Name="{x:Bind Title, Mode=OneTime}"
                         ThumbToolTipValueConverter="{x:Bind ThumbToolTipValueConverter, Mode=OneTime}"/>
-                </Grid>
-            </Border>
+            </Grid>
         </DataTemplate>
 
         <DataTemplate x:Key="SelectionItemTemplate" x:DataType="app:SettingInt32Item">
-            <Border Style="{StaticResource SettingsCardStyle}">
-                <Grid ColumnSpacing="24">
+            <Grid ColumnSpacing="24">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*"/>
                         <ColumnDefinition Width="Auto"/>
@@ -99,13 +93,11 @@
                         AutomationProperties.Name="{x:Bind Title, Mode=OneTime}"
                         ItemsSource="{x:Bind Options}"
                         SelectedIndex="{x:Bind Value, Mode=TwoWay}"/>
-                </Grid>
-            </Border>
+            </Grid>
         </DataTemplate>
 
         <DataTemplate x:Key="DataDirectoryItemTemplate" x:DataType="app:SettingDataDirectoryItem">
-            <Border Style="{StaticResource SettingsCardStyle}">
-                <Grid ColumnSpacing="8">
+            <Grid ColumnSpacing="8">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*"/>
                         <ColumnDefinition Width="Auto"/>
@@ -117,13 +109,11 @@
                     </StackPanel>
                     <Button Grid.Column="1" VerticalAlignment="Center" Click="DataDirectoryChangeButton_Click" Content="{x:Bind ChangeButtonTitle, Mode=OneTime}"/>
                     <Button Grid.Column="2" VerticalAlignment="Center" Click="DataDirectoryResetButton_Click" Content="{x:Bind ResetButtonTitle, Mode=OneTime}"/>
-                </Grid>
-            </Border>
+            </Grid>
         </DataTemplate>
 
         <DataTemplate x:Key="ConfigFileItemTemplate" x:DataType="app:SettingConfigFileItem">
-            <Border Style="{StaticResource SettingsCardStyle}">
-                <Grid ColumnSpacing="8">
+            <Grid ColumnSpacing="8">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*"/>
                         <ColumnDefinition Width="Auto"/>
@@ -135,8 +125,22 @@
                     </StackPanel>
                     <Button Grid.Column="1" VerticalAlignment="Center" Click="ConfigFileChangeButton_Click" Content="{x:Bind ChangeButtonTitle, Mode=OneTime}"/>
                     <Button Grid.Column="2" VerticalAlignment="Center" Click="ConfigFileResetButton_Click" Content="{x:Bind ResetButtonTitle, Mode=OneTime}"/>
-                </Grid>
-            </Border>
+            </Grid>
+        </DataTemplate>
+
+        <DataTemplate x:Key="HeaderItemTemplate" x:DataType="app:SettingHeaderItem">
+            <StackPanel>
+                <TextBlock Style="{StaticResource SettingsSectionHeaderStyle}" Text="{x:Bind Title, Mode=OneTime}"/>
+                <TextBlock
+                    Margin="1,-2,0,6"
+                    Style="{StaticResource SettingDescriptionStyle}"
+                    Text="{x:Bind Description, Mode=OneTime}"
+                    Visibility="{x:Bind DescriptionVisibility, Mode=OneTime}"/>
+            </StackPanel>
+        </DataTemplate>
+
+        <DataTemplate x:Key="SeparatorItemTemplate" x:DataType="local:SettingGroupSeparator">
+            <Grid Height="4"/>
         </DataTemplate>
 
         <local:SettingTemplateSelector
@@ -144,36 +148,24 @@
             Toggle="{StaticResource ToggleItemTemplate}"
             Slider="{StaticResource SliderItemTemplate}"
             Selection="{StaticResource SelectionItemTemplate}"
+            Header="{StaticResource HeaderItemTemplate}"
+            Separator="{StaticResource SeparatorItemTemplate}"
             DataDirectory="{StaticResource DataDirectoryItemTemplate}"
             ConfigFile="{StaticResource ConfigFileItemTemplate}"/>
 
-        <DataTemplate x:Key="SettingGroupTemplate" x:DataType="local:SettingItemGroup">
-            <StackPanel Margin="0,0,0,4">
-                <StackPanel Visibility="{x:Bind HeaderVisible, Mode=OneWay}">
-                    <TextBlock Style="{StaticResource SettingsSectionHeaderStyle}" Text="{x:Bind Title, Mode=OneTime}"/>
-                    <TextBlock
-                        Margin="1,-2,0,6"
-                        Style="{StaticResource SettingDescriptionStyle}"
-                        Text="{x:Bind Description, Mode=OneTime}"
-                        Visibility="{x:Bind DescriptionVisible, Mode=OneTime}"/>
-                </StackPanel>
+        <DataTemplate x:Key="SettingListItemTemplate" x:DataType="local:SettingListItem">
+            <Grid Margin="{x:Bind Margin, Mode=OneWay}">
                 <Border
-                    Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
-                    BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
-                    BorderThickness="1"
-                    CornerRadius="4">
-                    <ItemsControl
-                        Margin="0,0,0,-1"
-                        ItemsSource="{x:Bind Items}"
-                        ItemTemplateSelector="{StaticResource SettingsTemplateSelector}">
-                        <ItemsControl.ItemContainerStyle>
-                            <Style TargetType="ContentPresenter">
-                                <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
-                            </Style>
-                        </ItemsControl.ItemContainerStyle>
-                    </ItemsControl>
-                </Border>
-            </StackPanel>
+                    Style="{StaticResource SettingsCardStyle}"
+                    BorderThickness="{x:Bind BorderThickness, Mode=OneWay}"
+                    CornerRadius="{x:Bind CornerRadius, Mode=OneWay}"
+                    Visibility="{x:Bind SettingVisibility, Mode=OneTime}"/>
+                <ContentControl
+                    Margin="{x:Bind ContentMargin, Mode=OneTime}"
+                    HorizontalContentAlignment="Stretch"
+                    Content="{x:Bind Item, Mode=OneTime}"
+                    ContentTemplateSelector="{StaticResource SettingsTemplateSelector}"/>
+            </Grid>
         </DataTemplate>
     </UserControl.Resources>
     <RelativePanel>
@@ -194,19 +186,17 @@
             RelativePanel.Below="RestartHint"
             VerticalScrollBarVisibility="Auto"
             VerticalScrollMode="Auto">
-            <ItemsControl
+            <ItemsRepeater
                 x:Name="SettingsItems"
                 Margin="36,0,36,36"
                 MaxWidth="1064"
                 HorizontalAlignment="Stretch"
-                ItemsSource="{x:Bind Groups}"
-                ItemTemplate="{StaticResource SettingGroupTemplate}">
-                <ItemsControl.ItemContainerStyle>
-                    <Style TargetType="ContentPresenter">
-                        <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
-                    </Style>
-                </ItemsControl.ItemContainerStyle>
-            </ItemsControl>
+                ItemsSource="{x:Bind Rows}"
+                ItemTemplate="{StaticResource SettingListItemTemplate}">
+                <ItemsRepeater.Layout>
+                    <StackLayout Orientation="Vertical"/>
+                </ItemsRepeater.Layout>
+            </ItemsRepeater>
         </ScrollView>
 
         <VisualStateManager.VisualStateGroups>

--- a/CelestiaWinUI/SettingCommonUserControl.xaml
+++ b/CelestiaWinUI/SettingCommonUserControl.xaml
@@ -79,47 +79,24 @@
 
         <DataTemplate x:Key="SelectionItemTemplate" x:DataType="app:SettingInt32Item">
             <Border Style="{StaticResource SettingsCardStyle}">
-                <Grid x:Name="SelectionLayout" ColumnSpacing="24" RowSpacing="12">
+                <Grid ColumnSpacing="24">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*"/>
                         <ColumnDefinition Width="Auto"/>
                     </Grid.ColumnDefinitions>
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                    </Grid.RowDefinitions>
                     <StackPanel VerticalAlignment="Center" Spacing="2">
                         <TextBlock Style="{StaticResource SettingTitleStyle}" Text="{x:Bind Title, Mode=OneTime}"/>
                         <TextBlock Style="{StaticResource SettingDescriptionStyle}" Text="{x:Bind Note, Mode=OneTime}" Visibility="{x:Bind NoteVisibility, Mode=OneTime}"/>
                     </StackPanel>
                     <ComboBox
-                        x:Name="SelectionControl"
-                        Grid.Row="1"
+                        Grid.Column="1"
                         MinWidth="180"
-                        HorizontalAlignment="Stretch"
+                        MaxWidth="240"
+                        HorizontalAlignment="Right"
+                        VerticalAlignment="Center"
                         AutomationProperties.Name="{x:Bind Title, Mode=OneTime}"
                         ItemsSource="{x:Bind Options}"
                         SelectedIndex="{x:Bind Value, Mode=TwoWay}"/>
-
-                    <VisualStateManager.VisualStateGroups>
-                        <VisualStateGroup>
-                            <VisualState x:Name="NarrowSelectionLayout">
-                                <VisualState.StateTriggers>
-                                    <AdaptiveTrigger MinWindowWidth="0"/>
-                                </VisualState.StateTriggers>
-                            </VisualState>
-                            <VisualState x:Name="WideSelectionLayout">
-                                <VisualState.StateTriggers>
-                                    <AdaptiveTrigger MinWindowWidth="560"/>
-                                </VisualState.StateTriggers>
-                                <VisualState.Setters>
-                                    <Setter Target="SelectionControl.(Grid.Row)" Value="0"/>
-                                    <Setter Target="SelectionControl.(Grid.Column)" Value="1"/>
-                                    <Setter Target="SelectionControl.HorizontalAlignment" Value="Right"/>
-                                </VisualState.Setters>
-                            </VisualState>
-                        </VisualStateGroup>
-                    </VisualStateManager.VisualStateGroups>
                 </Grid>
             </Border>
         </DataTemplate>

--- a/CelestiaWinUI/SettingCommonUserControl.xaml
+++ b/CelestiaWinUI/SettingCommonUserControl.xaml
@@ -196,7 +196,7 @@
             VerticalScrollMode="Auto">
             <ItemsControl
                 x:Name="SettingsItems"
-                Margin="36,0"
+                Margin="36,0,36,36"
                 MaxWidth="1064"
                 HorizontalAlignment="Stretch"
                 ItemsSource="{x:Bind Groups}"
@@ -217,7 +217,7 @@
                     </VisualState.StateTriggers>
                     <VisualState.Setters>
                         <Setter Target="RestartHint.Margin" Value="20,0,20,8"/>
-                        <Setter Target="SettingsItems.Margin" Value="20,0"/>
+                        <Setter Target="SettingsItems.Margin" Value="20,0,20,24"/>
                     </VisualState.Setters>
                 </VisualState>
                 <VisualState x:Name="WideLayout">
@@ -226,7 +226,7 @@
                     </VisualState.StateTriggers>
                     <VisualState.Setters>
                         <Setter Target="RestartHint.Margin" Value="36,0,36,8"/>
-                        <Setter Target="SettingsItems.Margin" Value="36,0"/>
+                        <Setter Target="SettingsItems.Margin" Value="36,0,36,36"/>
                     </VisualState.Setters>
                 </VisualState>
             </VisualStateGroup>

--- a/CelestiaWinUI/SettingCommonUserControl.xaml
+++ b/CelestiaWinUI/SettingCommonUserControl.xaml
@@ -55,18 +55,20 @@
 
         <DataTemplate x:Key="SliderItemTemplate" x:DataType="app:SettingDoubleItem">
             <Border Style="{StaticResource SettingsCardStyle}">
-                <Grid RowSpacing="8">
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                    </Grid.RowDefinitions>
-                    <StackPanel Spacing="2">
+                <Grid ColumnSpacing="24">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+                    <StackPanel VerticalAlignment="Center" Spacing="2">
                         <TextBlock Style="{StaticResource SettingTitleStyle}" Text="{x:Bind Title, Mode=OneTime}"/>
                         <TextBlock Style="{StaticResource SettingDescriptionStyle}" Text="{x:Bind Note, Mode=OneTime}" Visibility="{x:Bind NoteVisibility, Mode=OneTime}"/>
                     </StackPanel>
                     <Slider
-                        Grid.Row="1"
+                        Grid.Column="1"
+                        Width="240"
                         Margin="-8,0"
+                        VerticalAlignment="Center"
                         Minimum="{x:Bind MinValue}"
                         Maximum="{x:Bind MaxValue}"
                         StepFrequency="{x:Bind Step}"

--- a/CelestiaWinUI/SettingCommonUserControl.xaml
+++ b/CelestiaWinUI/SettingCommonUserControl.xaml
@@ -103,90 +103,36 @@
 
         <DataTemplate x:Key="DataDirectoryItemTemplate" x:DataType="app:SettingDataDirectoryItem">
             <Border Style="{StaticResource SettingsCardStyle}">
-                <Grid x:Name="DirectoryLayout" ColumnSpacing="8" RowSpacing="12">
+                <Grid ColumnSpacing="8">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*"/>
                         <ColumnDefinition Width="Auto"/>
                         <ColumnDefinition Width="Auto"/>
                     </Grid.ColumnDefinitions>
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                    </Grid.RowDefinitions>
-                    <StackPanel x:Name="DirectoryDescription" Grid.ColumnSpan="3" Spacing="2">
+                    <StackPanel Spacing="2" VerticalAlignment="Center">
                         <TextBlock Style="{StaticResource SettingTitleStyle}" Text="{x:Bind Title, Mode=OneTime}"/>
                         <TextBlock Style="{StaticResource SettingDescriptionStyle}" TextTrimming="CharacterEllipsis" Text="{x:Bind DisplayValue, Mode=OneWay}"/>
                     </StackPanel>
-                    <Button x:Name="DirectoryChangeButton" Grid.Row="2" Click="DataDirectoryChangeButton_Click" Content="{x:Bind ChangeButtonTitle, Mode=OneTime}"/>
-                    <Button x:Name="DirectoryResetButton" Grid.Row="2" Grid.Column="1" Click="DataDirectoryResetButton_Click" Content="{x:Bind ResetButtonTitle, Mode=OneTime}"/>
-
-                    <VisualStateManager.VisualStateGroups>
-                        <VisualStateGroup>
-                            <VisualState x:Name="NarrowDirectoryLayout">
-                                <VisualState.StateTriggers>
-                                    <AdaptiveTrigger MinWindowWidth="0"/>
-                                </VisualState.StateTriggers>
-                            </VisualState>
-                            <VisualState x:Name="WideDirectoryLayout">
-                                <VisualState.StateTriggers>
-                                    <AdaptiveTrigger MinWindowWidth="700"/>
-                                </VisualState.StateTriggers>
-                                <VisualState.Setters>
-                                    <Setter Target="DirectoryChangeButton.(Grid.Row)" Value="0"/>
-                                    <Setter Target="DirectoryChangeButton.(Grid.Column)" Value="1"/>
-                                    <Setter Target="DirectoryResetButton.(Grid.Row)" Value="0"/>
-                                    <Setter Target="DirectoryResetButton.(Grid.Column)" Value="2"/>
-                                    <Setter Target="DirectoryDescription.(Grid.ColumnSpan)" Value="1"/>
-                                </VisualState.Setters>
-                            </VisualState>
-                        </VisualStateGroup>
-                    </VisualStateManager.VisualStateGroups>
+                    <Button Grid.Column="1" VerticalAlignment="Center" Click="DataDirectoryChangeButton_Click" Content="{x:Bind ChangeButtonTitle, Mode=OneTime}"/>
+                    <Button Grid.Column="2" VerticalAlignment="Center" Click="DataDirectoryResetButton_Click" Content="{x:Bind ResetButtonTitle, Mode=OneTime}"/>
                 </Grid>
             </Border>
         </DataTemplate>
 
         <DataTemplate x:Key="ConfigFileItemTemplate" x:DataType="app:SettingConfigFileItem">
             <Border Style="{StaticResource SettingsCardStyle}">
-                <Grid x:Name="ConfigLayout" ColumnSpacing="8" RowSpacing="12">
+                <Grid ColumnSpacing="8">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*"/>
                         <ColumnDefinition Width="Auto"/>
                         <ColumnDefinition Width="Auto"/>
                     </Grid.ColumnDefinitions>
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                    </Grid.RowDefinitions>
-                    <StackPanel x:Name="ConfigDescription" Grid.ColumnSpan="3" Spacing="2">
+                    <StackPanel Spacing="2" VerticalAlignment="Center">
                         <TextBlock Style="{StaticResource SettingTitleStyle}" Text="{x:Bind Title, Mode=OneTime}"/>
                         <TextBlock Style="{StaticResource SettingDescriptionStyle}" TextTrimming="CharacterEllipsis" Text="{x:Bind DisplayValue, Mode=OneWay}"/>
                     </StackPanel>
-                    <Button x:Name="ConfigChangeButton" Grid.Row="2" Click="ConfigFileChangeButton_Click" Content="{x:Bind ChangeButtonTitle, Mode=OneTime}"/>
-                    <Button x:Name="ConfigResetButton" Grid.Row="2" Grid.Column="1" Click="ConfigFileResetButton_Click" Content="{x:Bind ResetButtonTitle, Mode=OneTime}"/>
-
-                    <VisualStateManager.VisualStateGroups>
-                        <VisualStateGroup>
-                            <VisualState x:Name="NarrowConfigLayout">
-                                <VisualState.StateTriggers>
-                                    <AdaptiveTrigger MinWindowWidth="0"/>
-                                </VisualState.StateTriggers>
-                            </VisualState>
-                            <VisualState x:Name="WideConfigLayout">
-                                <VisualState.StateTriggers>
-                                    <AdaptiveTrigger MinWindowWidth="700"/>
-                                </VisualState.StateTriggers>
-                                <VisualState.Setters>
-                                    <Setter Target="ConfigChangeButton.(Grid.Row)" Value="0"/>
-                                    <Setter Target="ConfigChangeButton.(Grid.Column)" Value="1"/>
-                                    <Setter Target="ConfigResetButton.(Grid.Row)" Value="0"/>
-                                    <Setter Target="ConfigResetButton.(Grid.Column)" Value="2"/>
-                                    <Setter Target="ConfigDescription.(Grid.ColumnSpan)" Value="1"/>
-                                </VisualState.Setters>
-                            </VisualState>
-                        </VisualStateGroup>
-                    </VisualStateManager.VisualStateGroups>
+                    <Button Grid.Column="1" VerticalAlignment="Center" Click="ConfigFileChangeButton_Click" Content="{x:Bind ChangeButtonTitle, Mode=OneTime}"/>
+                    <Button Grid.Column="2" VerticalAlignment="Center" Click="ConfigFileResetButton_Click" Content="{x:Bind ResetButtonTitle, Mode=OneTime}"/>
                 </Grid>
             </Border>
         </DataTemplate>

--- a/CelestiaWinUI/SettingCommonUserControl.xaml
+++ b/CelestiaWinUI/SettingCommonUserControl.xaml
@@ -9,92 +9,209 @@
     mc:Ignorable="d">
 
     <UserControl.Resources>
-        <x:Double x:Key="InternalColumnSpacing">8</x:Double>
-        <x:Double x:Key="InternalRowSpacing">4</x:Double>
+        <Style x:Key="SettingsCardStyle" TargetType="Border">
+            <Setter Property="BorderBrush" Value="{ThemeResource CardStrokeColorDefaultBrush}"/>
+            <Setter Property="BorderThickness" Value="0,0,0,1"/>
+            <Setter Property="Padding" Value="16"/>
+        </Style>
+
+        <Style x:Key="SettingTitleStyle" TargetType="TextBlock">
+            <Setter Property="VerticalAlignment" Value="Center"/>
+            <Setter Property="TextWrapping" Value="Wrap"/>
+        </Style>
+
+        <Style x:Key="SettingDescriptionStyle" TargetType="TextBlock" BasedOn="{StaticResource CaptionTextBlockStyle}">
+            <Setter Property="Foreground" Value="{ThemeResource TextFillColorSecondaryBrush}"/>
+            <Setter Property="TextWrapping" Value="Wrap"/>
+        </Style>
+
+        <Style x:Key="SettingsSectionHeaderStyle" TargetType="TextBlock" BasedOn="{StaticResource BodyStrongTextBlockStyle}">
+            <Setter Property="Margin" Value="1,30,0,6"/>
+            <Setter Property="AutomationProperties.HeadingLevel" Value="Level2"/>
+        </Style>
+
         <DataTemplate x:Key="ToggleItemTemplate" x:DataType="app:SettingBooleanItem">
-            <Grid VerticalAlignment="Center" RowSpacing="{StaticResource InternalRowSpacing}" Margin="{StaticResource ListItemMargin}">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto" />
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="Auto" />
-                </Grid.ColumnDefinitions>
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                </Grid.RowDefinitions>
-                <TextBlock Grid.Column="0" VerticalAlignment="Center" Text="{x:Bind Title, Mode=OneTime}"/>
-                <CheckBox MinWidth="0" Grid.Column="2" VerticalAlignment="Center" IsChecked="{x:Bind IsEnabled, Mode=TwoWay}"/>
-                <TextBlock Grid.Row="1" Grid.ColumnSpan="3" Style="{StaticResource CaptionTextBlockStyle}" Text="{x:Bind Note, Mode=OneTime}" Visibility="{x:Bind NoteVisibility, Mode=OneTime}"/>
-            </Grid>
+            <Border Style="{StaticResource SettingsCardStyle}">
+                <Grid ColumnSpacing="24">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+                    <StackPanel VerticalAlignment="Center" Spacing="2">
+                        <TextBlock Style="{StaticResource SettingTitleStyle}" Text="{x:Bind Title, Mode=OneTime}"/>
+                        <TextBlock Style="{StaticResource SettingDescriptionStyle}" Text="{x:Bind Note, Mode=OneTime}" Visibility="{x:Bind NoteVisibility, Mode=OneTime}"/>
+                    </StackPanel>
+                    <ToggleSwitch
+                        Grid.Column="1"
+                        MinWidth="0"
+                        VerticalAlignment="Center"
+                        OffContent=""
+                        OnContent=""
+                        AutomationProperties.Name="{x:Bind Title, Mode=OneTime}"
+                        IsOn="{x:Bind IsEnabled, Mode=TwoWay}"/>
+                </Grid>
+            </Border>
         </DataTemplate>
 
         <DataTemplate x:Key="SliderItemTemplate" x:DataType="app:SettingDoubleItem">
-            <Grid RowSpacing="{StaticResource InternalRowSpacing}" Margin="{StaticResource ListItemMargin}">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                </Grid.RowDefinitions>
-                <TextBlock Grid.Row="0" FontWeight="Bold" Text="{x:Bind Title}"/>
-                <Slider Grid.Row="1" Minimum="{x:Bind MinValue}" Maximum="{x:Bind MaxValue}" StepFrequency="{x:Bind Step}" Value="{x:Bind Value, Mode=TwoWay}" ThumbToolTipValueConverter="{x:Bind ThumbToolTipValueConverter, Mode=OneTime}"/>
-                <TextBlock Grid.Row="2" Style="{StaticResource CaptionTextBlockStyle}" Text="{x:Bind Note, Mode=OneTime}" Visibility="{x:Bind NoteVisibility, Mode=OneTime}"/>
-            </Grid>
+            <Border Style="{StaticResource SettingsCardStyle}">
+                <Grid RowSpacing="8">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+                    <StackPanel Spacing="2">
+                        <TextBlock Style="{StaticResource SettingTitleStyle}" Text="{x:Bind Title, Mode=OneTime}"/>
+                        <TextBlock Style="{StaticResource SettingDescriptionStyle}" Text="{x:Bind Note, Mode=OneTime}" Visibility="{x:Bind NoteVisibility, Mode=OneTime}"/>
+                    </StackPanel>
+                    <Slider
+                        Grid.Row="1"
+                        Margin="-8,0"
+                        Minimum="{x:Bind MinValue}"
+                        Maximum="{x:Bind MaxValue}"
+                        StepFrequency="{x:Bind Step}"
+                        Value="{x:Bind Value, Mode=TwoWay}"
+                        AutomationProperties.Name="{x:Bind Title, Mode=OneTime}"
+                        ThumbToolTipValueConverter="{x:Bind ThumbToolTipValueConverter, Mode=OneTime}"/>
+                </Grid>
+            </Border>
         </DataTemplate>
 
         <DataTemplate x:Key="SelectionItemTemplate" x:DataType="app:SettingInt32Item">
-            <Grid VerticalAlignment="Center" RowSpacing="{StaticResource InternalRowSpacing}" Margin="{StaticResource ListItemMargin}">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto" />
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="Auto" />
-                </Grid.ColumnDefinitions>
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="Auto"/>
-                </Grid.RowDefinitions>
-                <TextBlock Grid.Column="0" VerticalAlignment="Center" Text="{x:Bind Title, Mode=OneTime}"/>
-                <ComboBox Grid.Column="2" VerticalAlignment="Center" ItemsSource="{x:Bind Options}" SelectedIndex="{x:Bind Value, Mode=TwoWay}"/>
-                <TextBlock Grid.Row="1" Grid.ColumnSpan="3" Style="{StaticResource CaptionTextBlockStyle}" Text="{x:Bind Note, Mode=OneTime}" Visibility="{x:Bind NoteVisibility, Mode=OneTime}"/>
-            </Grid>
+            <Border Style="{StaticResource SettingsCardStyle}">
+                <Grid x:Name="SelectionLayout" ColumnSpacing="24" RowSpacing="12">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+                    <StackPanel VerticalAlignment="Center" Spacing="2">
+                        <TextBlock Style="{StaticResource SettingTitleStyle}" Text="{x:Bind Title, Mode=OneTime}"/>
+                        <TextBlock Style="{StaticResource SettingDescriptionStyle}" Text="{x:Bind Note, Mode=OneTime}" Visibility="{x:Bind NoteVisibility, Mode=OneTime}"/>
+                    </StackPanel>
+                    <ComboBox
+                        x:Name="SelectionControl"
+                        Grid.Row="1"
+                        MinWidth="180"
+                        HorizontalAlignment="Stretch"
+                        AutomationProperties.Name="{x:Bind Title, Mode=OneTime}"
+                        ItemsSource="{x:Bind Options}"
+                        SelectedIndex="{x:Bind Value, Mode=TwoWay}"/>
+
+                    <VisualStateManager.VisualStateGroups>
+                        <VisualStateGroup>
+                            <VisualState x:Name="NarrowSelectionLayout">
+                                <VisualState.StateTriggers>
+                                    <AdaptiveTrigger MinWindowWidth="0"/>
+                                </VisualState.StateTriggers>
+                            </VisualState>
+                            <VisualState x:Name="WideSelectionLayout">
+                                <VisualState.StateTriggers>
+                                    <AdaptiveTrigger MinWindowWidth="560"/>
+                                </VisualState.StateTriggers>
+                                <VisualState.Setters>
+                                    <Setter Target="SelectionControl.(Grid.Row)" Value="0"/>
+                                    <Setter Target="SelectionControl.(Grid.Column)" Value="1"/>
+                                    <Setter Target="SelectionControl.HorizontalAlignment" Value="Right"/>
+                                </VisualState.Setters>
+                            </VisualState>
+                        </VisualStateGroup>
+                    </VisualStateManager.VisualStateGroups>
+                </Grid>
+            </Border>
         </DataTemplate>
 
         <DataTemplate x:Key="DataDirectoryItemTemplate" x:DataType="app:SettingDataDirectoryItem">
-            <Grid VerticalAlignment="Center" ColumnSpacing="{StaticResource InternalColumnSpacing}" Margin="{StaticResource ListItemMargin}">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto" />
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="Auto" />
-                    <ColumnDefinition Width="Auto" />
-                    <ColumnDefinition Width="Auto" />
-                </Grid.ColumnDefinitions>
-                <TextBlock Grid.Column="0" VerticalAlignment="Center" Text="{x:Bind Title, Mode=OneTime}"/>
-                <TextBlock MinWidth="0" Grid.Column="2" VerticalAlignment="Center" Text="{x:Bind DisplayValue, Mode=OneWay}"/>
-                <Button Grid.Column="3" Click="DataDirectoryChangeButton_Click" Content="{x:Bind ChangeButtonTitle, Mode=OneTime}"/>
-                <Button Grid.Column="4" Click="DataDirectoryResetButton_Click" Content="{x:Bind ResetButtonTitle, Mode=OneTime}"/>
-            </Grid>
+            <Border Style="{StaticResource SettingsCardStyle}">
+                <Grid x:Name="DirectoryLayout" ColumnSpacing="8" RowSpacing="12">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+                    <StackPanel x:Name="DirectoryDescription" Grid.ColumnSpan="3" Spacing="2">
+                        <TextBlock Style="{StaticResource SettingTitleStyle}" Text="{x:Bind Title, Mode=OneTime}"/>
+                        <TextBlock Style="{StaticResource SettingDescriptionStyle}" TextTrimming="CharacterEllipsis" Text="{x:Bind DisplayValue, Mode=OneWay}"/>
+                    </StackPanel>
+                    <Button x:Name="DirectoryChangeButton" Grid.Row="2" Click="DataDirectoryChangeButton_Click" Content="{x:Bind ChangeButtonTitle, Mode=OneTime}"/>
+                    <Button x:Name="DirectoryResetButton" Grid.Row="2" Grid.Column="1" Click="DataDirectoryResetButton_Click" Content="{x:Bind ResetButtonTitle, Mode=OneTime}"/>
+
+                    <VisualStateManager.VisualStateGroups>
+                        <VisualStateGroup>
+                            <VisualState x:Name="NarrowDirectoryLayout">
+                                <VisualState.StateTriggers>
+                                    <AdaptiveTrigger MinWindowWidth="0"/>
+                                </VisualState.StateTriggers>
+                            </VisualState>
+                            <VisualState x:Name="WideDirectoryLayout">
+                                <VisualState.StateTriggers>
+                                    <AdaptiveTrigger MinWindowWidth="700"/>
+                                </VisualState.StateTriggers>
+                                <VisualState.Setters>
+                                    <Setter Target="DirectoryChangeButton.(Grid.Row)" Value="0"/>
+                                    <Setter Target="DirectoryChangeButton.(Grid.Column)" Value="1"/>
+                                    <Setter Target="DirectoryResetButton.(Grid.Row)" Value="0"/>
+                                    <Setter Target="DirectoryResetButton.(Grid.Column)" Value="2"/>
+                                    <Setter Target="DirectoryDescription.(Grid.ColumnSpan)" Value="1"/>
+                                </VisualState.Setters>
+                            </VisualState>
+                        </VisualStateGroup>
+                    </VisualStateManager.VisualStateGroups>
+                </Grid>
+            </Border>
         </DataTemplate>
 
         <DataTemplate x:Key="ConfigFileItemTemplate" x:DataType="app:SettingConfigFileItem">
-            <Grid VerticalAlignment="Center" ColumnSpacing="{StaticResource InternalColumnSpacing}" Margin="{StaticResource ListItemMargin}">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="Auto" />
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="Auto" />
-                    <ColumnDefinition Width="Auto" />
-                    <ColumnDefinition Width="Auto" />
-                </Grid.ColumnDefinitions>
-                <TextBlock Grid.Column="0" VerticalAlignment="Center" Text="{x:Bind Title, Mode=OneTime}"/>
-                <TextBlock MinWidth="0" Grid.Column="2" VerticalAlignment="Center" Text="{x:Bind DisplayValue, Mode=OneWay}"/>
-                <Button Grid.Column="3" Click="ConfigFileChangeButton_Click" Content="{x:Bind ChangeButtonTitle, Mode=OneTime}"/>
-                <Button Grid.Column="4" Click="ConfigFileResetButton_Click" Content="{x:Bind ResetButtonTitle, Mode=OneTime}"/>
-            </Grid>
-        </DataTemplate>
+            <Border Style="{StaticResource SettingsCardStyle}">
+                <Grid x:Name="ConfigLayout" ColumnSpacing="8" RowSpacing="12">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+                    <StackPanel x:Name="ConfigDescription" Grid.ColumnSpan="3" Spacing="2">
+                        <TextBlock Style="{StaticResource SettingTitleStyle}" Text="{x:Bind Title, Mode=OneTime}"/>
+                        <TextBlock Style="{StaticResource SettingDescriptionStyle}" TextTrimming="CharacterEllipsis" Text="{x:Bind DisplayValue, Mode=OneWay}"/>
+                    </StackPanel>
+                    <Button x:Name="ConfigChangeButton" Grid.Row="2" Click="ConfigFileChangeButton_Click" Content="{x:Bind ChangeButtonTitle, Mode=OneTime}"/>
+                    <Button x:Name="ConfigResetButton" Grid.Row="2" Grid.Column="1" Click="ConfigFileResetButton_Click" Content="{x:Bind ResetButtonTitle, Mode=OneTime}"/>
 
-        <DataTemplate x:Key="HeaderItemTemplate" x:DataType="app:SettingHeaderItem">
-            <StackPanel Margin="{StaticResource ListItemMargin}" Spacing="{StaticResource InternalRowSpacing}">
-                <TextBlock Style="{StaticResource SubtitleTextBlockStyle}" VerticalAlignment="Center" Text="{x:Bind Title, Mode=OneTime}"/>
-                <TextBlock Style="{StaticResource CaptionTextBlockStyle}" TextWrapping="Wrap" Text="{x:Bind Description, Mode=OneTime}" Visibility="{x:Bind DescriptionVisibility, Mode=OneTime}"/>
-            </StackPanel>
+                    <VisualStateManager.VisualStateGroups>
+                        <VisualStateGroup>
+                            <VisualState x:Name="NarrowConfigLayout">
+                                <VisualState.StateTriggers>
+                                    <AdaptiveTrigger MinWindowWidth="0"/>
+                                </VisualState.StateTriggers>
+                            </VisualState>
+                            <VisualState x:Name="WideConfigLayout">
+                                <VisualState.StateTriggers>
+                                    <AdaptiveTrigger MinWindowWidth="700"/>
+                                </VisualState.StateTriggers>
+                                <VisualState.Setters>
+                                    <Setter Target="ConfigChangeButton.(Grid.Row)" Value="0"/>
+                                    <Setter Target="ConfigChangeButton.(Grid.Column)" Value="1"/>
+                                    <Setter Target="ConfigResetButton.(Grid.Row)" Value="0"/>
+                                    <Setter Target="ConfigResetButton.(Grid.Column)" Value="2"/>
+                                    <Setter Target="ConfigDescription.(Grid.ColumnSpan)" Value="1"/>
+                                </VisualState.Setters>
+                            </VisualState>
+                        </VisualStateGroup>
+                    </VisualStateManager.VisualStateGroups>
+                </Grid>
+            </Border>
         </DataTemplate>
 
         <local:SettingTemplateSelector
@@ -102,26 +219,64 @@
             Toggle="{StaticResource ToggleItemTemplate}"
             Slider="{StaticResource SliderItemTemplate}"
             Selection="{StaticResource SelectionItemTemplate}"
-            Header="{StaticResource HeaderItemTemplate}"
             DataDirectory="{StaticResource DataDirectoryItemTemplate}"
             ConfigFile="{StaticResource ConfigFileItemTemplate}"/>
+
+        <DataTemplate x:Key="SettingGroupTemplate" x:DataType="local:SettingItemGroup">
+            <StackPanel Margin="0,0,0,4">
+                <StackPanel Visibility="{x:Bind HeaderVisible, Mode=OneWay}">
+                    <TextBlock Style="{StaticResource SettingsSectionHeaderStyle}" Text="{x:Bind Title, Mode=OneTime}"/>
+                    <TextBlock
+                        Margin="1,-2,0,6"
+                        Style="{StaticResource SettingDescriptionStyle}"
+                        Text="{x:Bind Description, Mode=OneTime}"
+                        Visibility="{x:Bind DescriptionVisible, Mode=OneTime}"/>
+                </StackPanel>
+                <Border
+                    Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                    BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                    BorderThickness="1"
+                    CornerRadius="4">
+                    <ItemsControl
+                        Margin="0,0,0,-1"
+                        ItemsSource="{x:Bind Items}"
+                        ItemTemplateSelector="{StaticResource SettingsTemplateSelector}">
+                        <ItemsControl.ItemContainerStyle>
+                            <Style TargetType="ContentPresenter">
+                                <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+                            </Style>
+                        </ItemsControl.ItemContainerStyle>
+                    </ItemsControl>
+                </Border>
+            </StackPanel>
+        </DataTemplate>
     </UserControl.Resources>
     <RelativePanel>
-        <InfoBar x:Name="RestartHint" IsOpen="{x:Bind ShowRestartHint, Mode=OneTime}" IsClosable="False" RelativePanel.AlignLeftWithPanel="True" RelativePanel.AlignRightWithPanel="True" RelativePanel.AlignTopWithPanel="True"/>
-        <ListView
+        <InfoBar
+            x:Name="RestartHint"
+            Margin="0,0,0,8"
+            IsOpen="{x:Bind ShowRestartHint, Mode=OneTime}"
+            IsClosable="False"
+            Severity="Informational"
+            RelativePanel.AlignLeftWithPanel="True"
+            RelativePanel.AlignRightWithPanel="True"
+            RelativePanel.AlignTopWithPanel="True"/>
+        <ScrollViewer
             RelativePanel.AlignBottomWithPanel="True"
             RelativePanel.AlignLeftWithPanel="True"
             RelativePanel.AlignRightWithPanel="True"
             RelativePanel.Below="RestartHint"
-            SelectionMode="None"
-            ItemsSource = "{x:Bind Items}"
-            ItemTemplateSelector = "{StaticResource SettingsTemplateSelector}">
-            <ListView.ItemContainerStyle>
-                <Style TargetType="ListViewItem">
-                    <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
-                    <Setter Property="IsTabStop" Value="False"/>
-                </Style>
-            </ListView.ItemContainerStyle>
-        </ListView>
+            VerticalScrollBarVisibility="Auto"
+            VerticalScrollMode="Auto">
+            <ItemsControl
+                ItemsSource="{x:Bind Groups}"
+                ItemTemplate="{StaticResource SettingGroupTemplate}">
+                <ItemsControl.ItemContainerStyle>
+                    <Style TargetType="ContentPresenter">
+                        <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+                    </Style>
+                </ItemsControl.ItemContainerStyle>
+            </ItemsControl>
+        </ScrollViewer>
     </RelativePanel>
 </UserControl>

--- a/CelestiaWinUI/SettingCommonUserControl.xaml
+++ b/CelestiaWinUI/SettingCommonUserControl.xaml
@@ -254,7 +254,8 @@
     <RelativePanel>
         <InfoBar
             x:Name="RestartHint"
-            Margin="0,0,0,8"
+            Margin="36,0,36,8"
+            MaxWidth="1064"
             IsOpen="{x:Bind ShowRestartHint, Mode=OneTime}"
             IsClosable="False"
             Severity="Informational"
@@ -269,6 +270,10 @@
             VerticalScrollBarVisibility="Auto"
             VerticalScrollMode="Auto">
             <ItemsControl
+                x:Name="SettingsItems"
+                Margin="36,0"
+                MaxWidth="1064"
+                HorizontalAlignment="Stretch"
                 ItemsSource="{x:Bind Groups}"
                 ItemTemplate="{StaticResource SettingGroupTemplate}">
                 <ItemsControl.ItemContainerStyle>
@@ -278,5 +283,28 @@
                 </ItemsControl.ItemContainerStyle>
             </ItemsControl>
         </ScrollViewer>
+
+        <VisualStateManager.VisualStateGroups>
+            <VisualStateGroup>
+                <VisualState x:Name="NarrowLayout">
+                    <VisualState.StateTriggers>
+                        <AdaptiveTrigger MinWindowWidth="0"/>
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Target="RestartHint.Margin" Value="20,0,20,8"/>
+                        <Setter Target="SettingsItems.Margin" Value="20,0"/>
+                    </VisualState.Setters>
+                </VisualState>
+                <VisualState x:Name="WideLayout">
+                    <VisualState.StateTriggers>
+                        <AdaptiveTrigger MinWindowWidth="700"/>
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Target="RestartHint.Margin" Value="36,0,36,8"/>
+                        <Setter Target="SettingsItems.Margin" Value="36,0"/>
+                    </VisualState.Setters>
+                </VisualState>
+            </VisualStateGroup>
+        </VisualStateManager.VisualStateGroups>
     </RelativePanel>
 </UserControl>

--- a/CelestiaWinUI/SettingCommonUserControl.xaml.cpp
+++ b/CelestiaWinUI/SettingCommonUserControl.xaml.cpp
@@ -12,8 +12,8 @@
 #if __has_include("SettingParameter.g.cpp")
 #include "SettingParameter.g.cpp"
 #endif
-#if __has_include("SettingItemGroup.g.cpp")
-#include "SettingItemGroup.g.cpp"
+#if __has_include("SettingListItem.g.cpp")
+#include "SettingListItem.g.cpp"
 #endif
 #if __has_include("SettingGroupSeparator.g.cpp")
 #include "SettingGroupSeparator.g.cpp"
@@ -78,6 +78,26 @@ namespace winrt::CelestiaWinUI::implementation
         slider = value;
     }
 
+    DataTemplate SettingTemplateSelector::Header()
+    {
+        return header;
+    }
+
+    void SettingTemplateSelector::Header(DataTemplate const& value)
+    {
+        header = value;
+    }
+
+    DataTemplate SettingTemplateSelector::Separator()
+    {
+        return separator;
+    }
+
+    void SettingTemplateSelector::Separator(DataTemplate const& value)
+    {
+        separator = value;
+    }
+
     DataTemplate SettingTemplateSelector::DataDirectory()
     {
         return dataDirectory;
@@ -108,88 +128,101 @@ namespace winrt::CelestiaWinUI::implementation
         if (item.try_as<SettingBooleanItem>() != nullptr) return toggle;
         if (item.try_as<SettingInt32Item>() != nullptr) return selection;
         if (item.try_as<SettingDoubleItem>() != nullptr) return slider;
+        if (item.try_as<SettingHeaderItem>() != nullptr) return header;
+        if (item.try_as<CelestiaWinUI::SettingGroupSeparator>() != nullptr) return separator;
         if (item.try_as<SettingDataDirectoryItem>() != nullptr) return dataDirectory;
         if (item.try_as<SettingConfigFileItem>() != nullptr) return configFile;
         return nullptr;
     }
 
-    SettingItemGroup::SettingItemGroup(hstring const& title, hstring const& description, bool headerVisible, bool descriptionVisible) :
-        title(title),
-        description(description),
-        headerVisible(headerVisible),
-        descriptionVisible(descriptionVisible),
-        items(single_threaded_observable_vector<IInspectable>())
+    SettingListItem::SettingListItem(IInspectable const& item, bool isSetting) :
+        item(item),
+        isSetting(isSetting),
+        borderThickness{},
+        cornerRadius{},
+        margin{},
+        contentMargin(isSetting ? Thickness{ 16, 16, 16, 16 } : Thickness{})
     {
     }
 
-    hstring SettingItemGroup::Title()
+    IInspectable SettingListItem::Item()
     {
-        return title;
+        return item;
     }
 
-    hstring SettingItemGroup::Description()
+    Visibility SettingListItem::SettingVisibility()
     {
-        return description;
+        return isSetting ? Visibility::Visible : Visibility::Collapsed;
     }
 
-    bool SettingItemGroup::HeaderVisible()
+    Thickness SettingListItem::BorderThickness()
     {
-        return headerVisible;
+        return borderThickness;
     }
 
-    void SettingItemGroup::HeaderVisible(bool value)
+    Microsoft::UI::Xaml::CornerRadius SettingListItem::CornerRadius()
     {
-        if (headerVisible == value)
-            return;
-        headerVisible = value;
-        propertyChangedEvent(*this, Data::PropertyChangedEventArgs(L"HeaderVisible"));
+        return cornerRadius;
     }
 
-    bool SettingItemGroup::DescriptionVisible()
+    Thickness SettingListItem::Margin()
     {
-        return descriptionVisible;
+        return margin;
     }
 
-    Collections::IObservableVector<IInspectable> SettingItemGroup::Items()
+    Thickness SettingListItem::ContentMargin()
     {
-        return items;
+        return contentMargin;
     }
 
-    event_token SettingItemGroup::PropertyChanged(Data::PropertyChangedEventHandler const& handler)
+    event_token SettingListItem::PropertyChanged(Data::PropertyChangedEventHandler const& handler)
     {
         return propertyChangedEvent.add(handler);
     }
 
-    void SettingItemGroup::PropertyChanged(event_token const& token) noexcept
+    void SettingListItem::PropertyChanged(event_token const& token) noexcept
     {
         propertyChangedEvent.remove(token);
     }
 
-    SettingCommonUserControl::SettingCommonUserControl(Collections::IObservableVector<IInspectable> const& settingItems, bool showRestartHint, CelestiaWinUI::SettingParameter const& parameter) : allItems(settingItems), groups(single_threaded_observable_vector<CelestiaWinUI::SettingItemGroup>()), showRestartHint(showRestartHint), parameter(parameter)
+    void SettingListItem::UpdateAppearance(Thickness const& valueBorderThickness, Microsoft::UI::Xaml::CornerRadius const& valueCornerRadius, Thickness const& valueMargin)
+    {
+        if (borderThickness.Left != valueBorderThickness.Left ||
+            borderThickness.Top != valueBorderThickness.Top ||
+            borderThickness.Right != valueBorderThickness.Right ||
+            borderThickness.Bottom != valueBorderThickness.Bottom)
+        {
+            borderThickness = valueBorderThickness;
+            propertyChangedEvent(*this, Data::PropertyChangedEventArgs(L"BorderThickness"));
+        }
+        if (cornerRadius.TopLeft != valueCornerRadius.TopLeft ||
+            cornerRadius.TopRight != valueCornerRadius.TopRight ||
+            cornerRadius.BottomRight != valueCornerRadius.BottomRight ||
+            cornerRadius.BottomLeft != valueCornerRadius.BottomLeft)
+        {
+            cornerRadius = valueCornerRadius;
+            propertyChangedEvent(*this, Data::PropertyChangedEventArgs(L"CornerRadius"));
+        }
+        if (margin.Left != valueMargin.Left ||
+            margin.Top != valueMargin.Top ||
+            margin.Right != valueMargin.Right ||
+            margin.Bottom != valueMargin.Bottom)
+        {
+            margin = valueMargin;
+            propertyChangedEvent(*this, Data::PropertyChangedEventArgs(L"Margin"));
+        }
+    }
+
+    SettingCommonUserControl::SettingCommonUserControl(Collections::IObservableVector<IInspectable> const& settingItems, bool showRestartHint, CelestiaWinUI::SettingParameter const& parameter) : allItems(settingItems), rows(single_threaded_observable_vector<CelestiaWinUI::SettingListItem>()), showRestartHint(showRestartHint), parameter(parameter)
     {
         for (auto const& item : allItems)
         {
-            if (item.try_as<CelestiaWinUI::SettingGroupSeparator>())
-            {
-                auto group = CelestiaWinUI::SettingItemGroup(L"", L"", false, false);
-                allGroups.push_back({ nullptr, {}, group });
-                continue;
-            }
-            else if (auto header = item.try_as<SettingHeaderItem>())
-            {
-                auto group = CelestiaWinUI::SettingItemGroup(header.Title(), header.Description(), true, header.DescriptionVisibility());
-                allGroups.push_back({ header, {}, group });
-            }
-            else
-            {
-                if (allGroups.empty())
-                {
-                    auto group = CelestiaWinUI::SettingItemGroup(L"", L"", false, false);
-                    allGroups.push_back({ nullptr, {}, group });
-                }
-                allGroups.back().allItems.push_back(item);
-            }
-
+            auto isSetting = item.try_as<SettingBooleanItem>() ||
+                item.try_as<SettingInt32Item>() ||
+                item.try_as<SettingDoubleItem>() ||
+                item.try_as<SettingDataDirectoryItem>() ||
+                item.try_as<SettingConfigFileItem>();
+            allRows.emplace_back(item, isSetting);
             auto settingItem = item.try_as<SettingBaseItem>();
             if (!settingItem)
                 continue;
@@ -213,58 +246,53 @@ namespace winrt::CelestiaWinUI::implementation
 
     void SettingCommonUserControl::RefreshVisibleItems()
     {
-        uint32_t visibleGroupIndex = 0;
-        for (auto const& state : allGroups)
+        uint32_t visibleIndex = 0;
+        for (auto const& row : allRows)
         {
-            auto visibleItems = state.group.Items();
-            uint32_t visibleItemIndex = 0;
-            for (auto const& item : state.allItems)
-            {
-                auto settingItem = item.try_as<SettingBaseItem>();
-                auto isVisible = !settingItem || settingItem.IsVisible();
-                uint32_t currentIndex;
-                auto isDisplayed = visibleItems.IndexOf(item, currentIndex);
-
-                if (!isVisible)
-                {
-                    if (isDisplayed)
-                        visibleItems.RemoveAt(currentIndex);
-                    continue;
-                }
-
-                if (!isDisplayed)
-                {
-                    visibleItems.InsertAt(visibleItemIndex, item);
-                }
-                else if (currentIndex != visibleItemIndex)
-                {
-                    visibleItems.RemoveAt(currentIndex);
-                    visibleItems.InsertAt(visibleItemIndex, item);
-                }
-                ++visibleItemIndex;
-            }
-
-            state.group.HeaderVisible(state.header && state.header.IsVisible());
-            auto isVisible = visibleItems.Size() > 0;
+            auto item = row.Item();
+            auto settingItem = item.try_as<SettingBaseItem>();
+            auto isVisible = !settingItem || settingItem.IsVisible();
             uint32_t currentIndex;
-            auto isDisplayed = groups.IndexOf(state.group, currentIndex);
+            auto isDisplayed = rows.IndexOf(row, currentIndex);
+
             if (!isVisible)
             {
                 if (isDisplayed)
-                    groups.RemoveAt(currentIndex);
+                    rows.RemoveAt(currentIndex);
                 continue;
             }
 
             if (!isDisplayed)
             {
-                groups.InsertAt(visibleGroupIndex, state.group);
+                rows.InsertAt(visibleIndex, row);
             }
-            else if (currentIndex != visibleGroupIndex)
+            else if (currentIndex != visibleIndex)
             {
-                groups.RemoveAt(currentIndex);
-                groups.InsertAt(visibleGroupIndex, state.group);
+                rows.RemoveAt(currentIndex);
+                rows.InsertAt(visibleIndex, row);
             }
-            ++visibleGroupIndex;
+            ++visibleIndex;
+        }
+
+        for (uint32_t index = 0; index < rows.Size(); ++index)
+        {
+            auto row = rows.GetAt(index);
+            if (row.SettingVisibility() != Visibility::Visible)
+                continue;
+
+            auto previousIsSetting = index > 0 && rows.GetAt(index - 1).SettingVisibility() == Visibility::Visible;
+            auto nextIsSetting = index + 1 < rows.Size() && rows.GetAt(index + 1).SettingVisibility() == Visibility::Visible;
+            Thickness borderThickness = previousIsSetting ? Thickness{ 1, 0, 1, 1 } : Thickness{ 1, 1, 1, 1 };
+            Microsoft::UI::Xaml::CornerRadius rowCornerRadius{};
+            if (!previousIsSetting && !nextIsSetting)
+                rowCornerRadius = { 4, 4, 4, 4 };
+            else if (!previousIsSetting)
+                rowCornerRadius = { 4, 4, 0, 0 };
+            else if (!nextIsSetting)
+                rowCornerRadius = { 0, 0, 4, 4 };
+
+            auto topMargin = index == 0 ? 30.0 : 0.0;
+            get_self<implementation::SettingListItem>(row)->UpdateAppearance(borderThickness, rowCornerRadius, { 0, topMargin, 0, 0 });
         }
     }
 
@@ -274,9 +302,9 @@ namespace winrt::CelestiaWinUI::implementation
         RestartHint().Title(LocalizationHelper::Localize(L"Some configurations will take effect after a restart.", L""));
     }
 
-    Collections::IObservableVector<CelestiaWinUI::SettingItemGroup> SettingCommonUserControl::Groups()
+    Collections::IObservableVector<CelestiaWinUI::SettingListItem> SettingCommonUserControl::Rows()
     {
-        return groups;
+        return rows;
     }
 
     bool SettingCommonUserControl::ShowRestartHint()

--- a/CelestiaWinUI/SettingCommonUserControl.xaml.cpp
+++ b/CelestiaWinUI/SettingCommonUserControl.xaml.cpp
@@ -12,6 +12,12 @@
 #if __has_include("SettingParameter.g.cpp")
 #include "SettingParameter.g.cpp"
 #endif
+#if __has_include("SettingItemGroup.g.cpp")
+#include "SettingItemGroup.g.cpp"
+#endif
+#if __has_include("SettingGroupSeparator.g.cpp")
+#include "SettingGroupSeparator.g.cpp"
+#endif
 #if __has_include("SettingCommonUserControl.g.cpp")
 #include "SettingCommonUserControl.g.cpp"
 #endif
@@ -72,16 +78,6 @@ namespace winrt::CelestiaWinUI::implementation
         slider = value;
     }
 
-    DataTemplate SettingTemplateSelector::Header()
-    {
-        return header;
-    }
-
-    void SettingTemplateSelector::Header(DataTemplate const& value)
-    {
-        header = value;
-    }
-
     DataTemplate SettingTemplateSelector::DataDirectory()
     {
         return dataDirectory;
@@ -112,16 +108,88 @@ namespace winrt::CelestiaWinUI::implementation
         if (item.try_as<SettingBooleanItem>() != nullptr) return toggle;
         if (item.try_as<SettingInt32Item>() != nullptr) return selection;
         if (item.try_as<SettingDoubleItem>() != nullptr) return slider;
-        if (item.try_as<SettingHeaderItem>() != nullptr) return header;
         if (item.try_as<SettingDataDirectoryItem>() != nullptr) return dataDirectory;
         if (item.try_as<SettingConfigFileItem>() != nullptr) return configFile;
         return nullptr;
     }
 
-    SettingCommonUserControl::SettingCommonUserControl(Collections::IObservableVector<IInspectable> const& settingItems, bool showRestartHint, CelestiaWinUI::SettingParameter const& parameter) : allItems(settingItems), items(single_threaded_observable_vector<IInspectable>()), showRestartHint(showRestartHint), parameter(parameter)
+    SettingItemGroup::SettingItemGroup(hstring const& title, hstring const& description, bool headerVisible, bool descriptionVisible) :
+        title(title),
+        description(description),
+        headerVisible(headerVisible),
+        descriptionVisible(descriptionVisible),
+        items(single_threaded_observable_vector<IInspectable>())
+    {
+    }
+
+    hstring SettingItemGroup::Title()
+    {
+        return title;
+    }
+
+    hstring SettingItemGroup::Description()
+    {
+        return description;
+    }
+
+    bool SettingItemGroup::HeaderVisible()
+    {
+        return headerVisible;
+    }
+
+    void SettingItemGroup::HeaderVisible(bool value)
+    {
+        if (headerVisible == value)
+            return;
+        headerVisible = value;
+        propertyChangedEvent(*this, Data::PropertyChangedEventArgs(L"HeaderVisible"));
+    }
+
+    bool SettingItemGroup::DescriptionVisible()
+    {
+        return descriptionVisible;
+    }
+
+    Collections::IObservableVector<IInspectable> SettingItemGroup::Items()
+    {
+        return items;
+    }
+
+    event_token SettingItemGroup::PropertyChanged(Data::PropertyChangedEventHandler const& handler)
+    {
+        return propertyChangedEvent.add(handler);
+    }
+
+    void SettingItemGroup::PropertyChanged(event_token const& token) noexcept
+    {
+        propertyChangedEvent.remove(token);
+    }
+
+    SettingCommonUserControl::SettingCommonUserControl(Collections::IObservableVector<IInspectable> const& settingItems, bool showRestartHint, CelestiaWinUI::SettingParameter const& parameter) : allItems(settingItems), groups(single_threaded_observable_vector<CelestiaWinUI::SettingItemGroup>()), showRestartHint(showRestartHint), parameter(parameter)
     {
         for (auto const& item : allItems)
         {
+            if (item.try_as<CelestiaWinUI::SettingGroupSeparator>())
+            {
+                auto group = CelestiaWinUI::SettingItemGroup(L"", L"", false, false);
+                allGroups.push_back({ nullptr, {}, group });
+                continue;
+            }
+            else if (auto header = item.try_as<SettingHeaderItem>())
+            {
+                auto group = CelestiaWinUI::SettingItemGroup(header.Title(), header.Description(), true, header.DescriptionVisibility());
+                allGroups.push_back({ header, {}, group });
+            }
+            else
+            {
+                if (allGroups.empty())
+                {
+                    auto group = CelestiaWinUI::SettingItemGroup(L"", L"", false, false);
+                    allGroups.push_back({ nullptr, {}, group });
+                }
+                allGroups.back().allItems.push_back(item);
+            }
+
             auto settingItem = item.try_as<SettingBaseItem>();
             if (!settingItem)
                 continue;
@@ -145,31 +213,58 @@ namespace winrt::CelestiaWinUI::implementation
 
     void SettingCommonUserControl::RefreshVisibleItems()
     {
-        uint32_t visibleIndex = 0;
-        for (auto const& item : allItems)
+        uint32_t visibleGroupIndex = 0;
+        for (auto const& state : allGroups)
         {
-            auto settingItem = item.try_as<SettingBaseItem>();
-            auto isVisible = !settingItem || settingItem.IsVisible();
-            uint32_t currentIndex;
-            auto isDisplayed = items.IndexOf(item, currentIndex);
+            auto visibleItems = state.group.Items();
+            uint32_t visibleItemIndex = 0;
+            for (auto const& item : state.allItems)
+            {
+                auto settingItem = item.try_as<SettingBaseItem>();
+                auto isVisible = !settingItem || settingItem.IsVisible();
+                uint32_t currentIndex;
+                auto isDisplayed = visibleItems.IndexOf(item, currentIndex);
 
+                if (!isVisible)
+                {
+                    if (isDisplayed)
+                        visibleItems.RemoveAt(currentIndex);
+                    continue;
+                }
+
+                if (!isDisplayed)
+                {
+                    visibleItems.InsertAt(visibleItemIndex, item);
+                }
+                else if (currentIndex != visibleItemIndex)
+                {
+                    visibleItems.RemoveAt(currentIndex);
+                    visibleItems.InsertAt(visibleItemIndex, item);
+                }
+                ++visibleItemIndex;
+            }
+
+            state.group.HeaderVisible(state.header && state.header.IsVisible());
+            auto isVisible = visibleItems.Size() > 0;
+            uint32_t currentIndex;
+            auto isDisplayed = groups.IndexOf(state.group, currentIndex);
             if (!isVisible)
             {
                 if (isDisplayed)
-                    items.RemoveAt(currentIndex);
+                    groups.RemoveAt(currentIndex);
                 continue;
             }
 
             if (!isDisplayed)
             {
-                items.InsertAt(visibleIndex, item);
+                groups.InsertAt(visibleGroupIndex, state.group);
             }
-            else if (currentIndex != visibleIndex)
+            else if (currentIndex != visibleGroupIndex)
             {
-                items.RemoveAt(currentIndex);
-                items.InsertAt(visibleIndex, item);
+                groups.RemoveAt(currentIndex);
+                groups.InsertAt(visibleGroupIndex, state.group);
             }
-            ++visibleIndex;
+            ++visibleGroupIndex;
         }
     }
 
@@ -179,9 +274,9 @@ namespace winrt::CelestiaWinUI::implementation
         RestartHint().Title(LocalizationHelper::Localize(L"Some configurations will take effect after a restart.", L""));
     }
 
-    Collections::IObservableVector<IInspectable> SettingCommonUserControl::Items()
+    Collections::IObservableVector<CelestiaWinUI::SettingItemGroup> SettingCommonUserControl::Groups()
     {
-        return items;
+        return groups;
     }
 
     bool SettingCommonUserControl::ShowRestartHint()

--- a/CelestiaWinUI/SettingCommonUserControl.xaml.h
+++ b/CelestiaWinUI/SettingCommonUserControl.xaml.h
@@ -11,7 +11,7 @@
 
 #include "SettingParameter.g.h"
 #include "SettingTemplateSelector.g.h"
-#include "SettingItemGroup.g.h"
+#include "SettingListItem.g.h"
 #include "SettingGroupSeparator.g.h"
 #include "SettingCommonUserControl.g.h"
 
@@ -35,6 +35,10 @@ namespace winrt::CelestiaWinUI::implementation
         void Selection(Microsoft::UI::Xaml::DataTemplate const&);
         Microsoft::UI::Xaml::DataTemplate Slider();
         void Slider(Microsoft::UI::Xaml::DataTemplate const&);
+        Microsoft::UI::Xaml::DataTemplate Header();
+        void Header(Microsoft::UI::Xaml::DataTemplate const&);
+        Microsoft::UI::Xaml::DataTemplate Separator();
+        void Separator(Microsoft::UI::Xaml::DataTemplate const&);
         Microsoft::UI::Xaml::DataTemplate DataDirectory();
         void DataDirectory(Microsoft::UI::Xaml::DataTemplate const&);
         Microsoft::UI::Xaml::DataTemplate ConfigFile();
@@ -47,30 +51,34 @@ namespace winrt::CelestiaWinUI::implementation
         Microsoft::UI::Xaml::DataTemplate toggle{ nullptr };
         Microsoft::UI::Xaml::DataTemplate selection{ nullptr };
         Microsoft::UI::Xaml::DataTemplate slider{ nullptr };
+        Microsoft::UI::Xaml::DataTemplate header{ nullptr };
+        Microsoft::UI::Xaml::DataTemplate separator{ nullptr };
         Microsoft::UI::Xaml::DataTemplate dataDirectory{ nullptr };
         Microsoft::UI::Xaml::DataTemplate configFile{ nullptr };
     };
 
-    struct SettingItemGroup : SettingItemGroupT<SettingItemGroup>
+    struct SettingListItem : SettingListItemT<SettingListItem>
     {
-        SettingItemGroup(hstring const& title, hstring const& description, bool headerVisible, bool descriptionVisible);
+        SettingListItem(Windows::Foundation::IInspectable const& item, bool isSetting);
 
-        hstring Title();
-        hstring Description();
-        bool HeaderVisible();
-        void HeaderVisible(bool);
-        bool DescriptionVisible();
-        Windows::Foundation::Collections::IObservableVector<Windows::Foundation::IInspectable> Items();
-
+        Windows::Foundation::IInspectable Item();
+        Microsoft::UI::Xaml::Visibility SettingVisibility();
+        Microsoft::UI::Xaml::Thickness BorderThickness();
+        Microsoft::UI::Xaml::CornerRadius CornerRadius();
+        Microsoft::UI::Xaml::Thickness Margin();
+        Microsoft::UI::Xaml::Thickness ContentMargin();
         event_token PropertyChanged(Microsoft::UI::Xaml::Data::PropertyChangedEventHandler const& handler);
         void PropertyChanged(event_token const& token) noexcept;
 
+        void UpdateAppearance(Microsoft::UI::Xaml::Thickness const& borderThickness, Microsoft::UI::Xaml::CornerRadius const& cornerRadius, Microsoft::UI::Xaml::Thickness const& margin);
+
     private:
-        hstring title;
-        hstring description;
-        bool headerVisible;
-        bool descriptionVisible;
-        Windows::Foundation::Collections::IObservableVector<Windows::Foundation::IInspectable> items;
+        Windows::Foundation::IInspectable item;
+        bool isSetting;
+        Microsoft::UI::Xaml::Thickness borderThickness;
+        Microsoft::UI::Xaml::CornerRadius cornerRadius;
+        Microsoft::UI::Xaml::Thickness margin;
+        Microsoft::UI::Xaml::Thickness contentMargin;
         event<Microsoft::UI::Xaml::Data::PropertyChangedEventHandler> propertyChangedEvent;
     };
 
@@ -85,7 +93,7 @@ namespace winrt::CelestiaWinUI::implementation
         ~SettingCommonUserControl();
         void InitializeComponent();
 
-        Windows::Foundation::Collections::IObservableVector<CelestiaWinUI::SettingItemGroup> Groups();
+        Windows::Foundation::Collections::IObservableVector<CelestiaWinUI::SettingListItem> Rows();
         bool ShowRestartHint();
 
         fire_and_forget DataDirectoryChangeButton_Click(Windows::Foundation::IInspectable const& sender, Microsoft::UI::Xaml::RoutedEventArgs const&);
@@ -94,16 +102,9 @@ namespace winrt::CelestiaWinUI::implementation
         void ConfigFileResetButton_Click(Windows::Foundation::IInspectable const& sender, Microsoft::UI::Xaml::RoutedEventArgs const&);
 
     private:
-        struct GroupState
-        {
-            CelestiaAppComponent::SettingHeaderItem header;
-            std::vector<Windows::Foundation::IInspectable> allItems;
-            CelestiaWinUI::SettingItemGroup group;
-        };
-
         Windows::Foundation::Collections::IObservableVector<Windows::Foundation::IInspectable> allItems;
-        std::vector<GroupState> allGroups;
-        Windows::Foundation::Collections::IObservableVector<CelestiaWinUI::SettingItemGroup> groups;
+        std::vector<CelestiaWinUI::SettingListItem> allRows;
+        Windows::Foundation::Collections::IObservableVector<CelestiaWinUI::SettingListItem> rows;
         std::vector<std::pair<CelestiaAppComponent::SettingBaseItem, event_token>> visibilitySubscriptions;
         bool showRestartHint;
         CelestiaWinUI::SettingParameter parameter;
@@ -122,7 +123,7 @@ namespace winrt::CelestiaWinUI::factory_implementation
     {
     };
 
-    struct SettingItemGroup : SettingItemGroupT<SettingItemGroup, implementation::SettingItemGroup>
+    struct SettingListItem : SettingListItemT<SettingListItem, implementation::SettingListItem>
     {
     };
 

--- a/CelestiaWinUI/SettingCommonUserControl.xaml.h
+++ b/CelestiaWinUI/SettingCommonUserControl.xaml.h
@@ -11,6 +11,8 @@
 
 #include "SettingParameter.g.h"
 #include "SettingTemplateSelector.g.h"
+#include "SettingItemGroup.g.h"
+#include "SettingGroupSeparator.g.h"
 #include "SettingCommonUserControl.g.h"
 
 namespace winrt::CelestiaWinUI::implementation
@@ -33,8 +35,6 @@ namespace winrt::CelestiaWinUI::implementation
         void Selection(Microsoft::UI::Xaml::DataTemplate const&);
         Microsoft::UI::Xaml::DataTemplate Slider();
         void Slider(Microsoft::UI::Xaml::DataTemplate const&);
-        Microsoft::UI::Xaml::DataTemplate Header();
-        void Header(Microsoft::UI::Xaml::DataTemplate const&);
         Microsoft::UI::Xaml::DataTemplate DataDirectory();
         void DataDirectory(Microsoft::UI::Xaml::DataTemplate const&);
         Microsoft::UI::Xaml::DataTemplate ConfigFile();
@@ -47,9 +47,36 @@ namespace winrt::CelestiaWinUI::implementation
         Microsoft::UI::Xaml::DataTemplate toggle{ nullptr };
         Microsoft::UI::Xaml::DataTemplate selection{ nullptr };
         Microsoft::UI::Xaml::DataTemplate slider{ nullptr };
-        Microsoft::UI::Xaml::DataTemplate header{ nullptr };
         Microsoft::UI::Xaml::DataTemplate dataDirectory{ nullptr };
         Microsoft::UI::Xaml::DataTemplate configFile{ nullptr };
+    };
+
+    struct SettingItemGroup : SettingItemGroupT<SettingItemGroup>
+    {
+        SettingItemGroup(hstring const& title, hstring const& description, bool headerVisible, bool descriptionVisible);
+
+        hstring Title();
+        hstring Description();
+        bool HeaderVisible();
+        void HeaderVisible(bool);
+        bool DescriptionVisible();
+        Windows::Foundation::Collections::IObservableVector<Windows::Foundation::IInspectable> Items();
+
+        event_token PropertyChanged(Microsoft::UI::Xaml::Data::PropertyChangedEventHandler const& handler);
+        void PropertyChanged(event_token const& token) noexcept;
+
+    private:
+        hstring title;
+        hstring description;
+        bool headerVisible;
+        bool descriptionVisible;
+        Windows::Foundation::Collections::IObservableVector<Windows::Foundation::IInspectable> items;
+        event<Microsoft::UI::Xaml::Data::PropertyChangedEventHandler> propertyChangedEvent;
+    };
+
+    struct SettingGroupSeparator : SettingGroupSeparatorT<SettingGroupSeparator>
+    {
+        SettingGroupSeparator() = default;
     };
 
     struct SettingCommonUserControl : SettingCommonUserControlT<SettingCommonUserControl>
@@ -58,7 +85,7 @@ namespace winrt::CelestiaWinUI::implementation
         ~SettingCommonUserControl();
         void InitializeComponent();
 
-        Windows::Foundation::Collections::IObservableVector<Windows::Foundation::IInspectable> Items();
+        Windows::Foundation::Collections::IObservableVector<CelestiaWinUI::SettingItemGroup> Groups();
         bool ShowRestartHint();
 
         fire_and_forget DataDirectoryChangeButton_Click(Windows::Foundation::IInspectable const& sender, Microsoft::UI::Xaml::RoutedEventArgs const&);
@@ -67,8 +94,16 @@ namespace winrt::CelestiaWinUI::implementation
         void ConfigFileResetButton_Click(Windows::Foundation::IInspectable const& sender, Microsoft::UI::Xaml::RoutedEventArgs const&);
 
     private:
+        struct GroupState
+        {
+            CelestiaAppComponent::SettingHeaderItem header;
+            std::vector<Windows::Foundation::IInspectable> allItems;
+            CelestiaWinUI::SettingItemGroup group;
+        };
+
         Windows::Foundation::Collections::IObservableVector<Windows::Foundation::IInspectable> allItems;
-        Windows::Foundation::Collections::IObservableVector<Windows::Foundation::IInspectable> items;
+        std::vector<GroupState> allGroups;
+        Windows::Foundation::Collections::IObservableVector<CelestiaWinUI::SettingItemGroup> groups;
         std::vector<std::pair<CelestiaAppComponent::SettingBaseItem, event_token>> visibilitySubscriptions;
         bool showRestartHint;
         CelestiaWinUI::SettingParameter parameter;
@@ -84,6 +119,14 @@ namespace winrt::CelestiaWinUI::factory_implementation
     };
 
     struct SettingTemplateSelector : SettingTemplateSelectorT<SettingTemplateSelector, implementation::SettingTemplateSelector>
+    {
+    };
+
+    struct SettingItemGroup : SettingItemGroupT<SettingItemGroup, implementation::SettingItemGroup>
+    {
+    };
+
+    struct SettingGroupSeparator : SettingGroupSeparatorT<SettingGroupSeparator, implementation::SettingGroupSeparator>
     {
     };
 

--- a/CelestiaWinUI/SettingsUserControl.idl
+++ b/CelestiaWinUI/SettingsUserControl.idl
@@ -14,8 +14,9 @@ namespace CelestiaWinUI
     [default_interface]
     runtimeclass SettingsNavigationItemGroup
     {
-        SettingsNavigationItemGroup(String title, Windows.Foundation.Collections.IObservableVector<Object> items, Boolean showRestartHint);
+        SettingsNavigationItemGroup(String title, Microsoft.UI.Xaml.Controls.Symbol icon, Windows.Foundation.Collections.IObservableVector<Object> items, Boolean showRestartHint);
         String Title{ get; };
+        Microsoft.UI.Xaml.Controls.Symbol Icon{ get; };
         Windows.Foundation.Collections.IObservableVector<Object> Items{ get; };
         Boolean ShowRestartHint{ get; };
     }

--- a/CelestiaWinUI/SettingsUserControl.idl
+++ b/CelestiaWinUI/SettingsUserControl.idl
@@ -25,5 +25,6 @@ namespace CelestiaWinUI
     {
         SettingsUserControl(CelestiaComponent.CelestiaAppCore appCore, CelestiaComponent.CelestiaRenderer renderer, CelestiaAppComponent.AppSettings appSettings, Microsoft.Windows.Storage.ApplicationDataContainer localSettings, Windows.Foundation.Collections.IVector<String> availableLanguages, Windows.Foundation.IReference<Int32> maximumDisplayFrequency, CelestiaComponent.DisplayInformation displayInformation, SettingParameter parameter);
         Windows.Foundation.Collections.IObservableVector<SettingsNavigationItemGroup> ItemGroups{ get; };
+        Microsoft.UI.Xaml.UIElement TitleBarElement{ get; };
     }
 }

--- a/CelestiaWinUI/SettingsUserControl.xaml
+++ b/CelestiaWinUI/SettingsUserControl.xaml
@@ -64,21 +64,12 @@
                 </Grid.RowDefinitions>
 
                 <Grid x:Name="HeaderLayout" Margin="36,24,36,0" MaxWidth="1064" HorizontalAlignment="Stretch">
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                    </Grid.RowDefinitions>
                     <TextBlock
                         x:Name="PageTitle"
                         Style="{StaticResource TitleTextBlockStyle}"
                         FontSize="28"
                         FontWeight="SemiBold"
                         AutomationProperties.HeadingLevel="Level1"/>
-                    <Rectangle
-                        Grid.Row="1"
-                        Height="1"
-                        Margin="0,12,0,0"
-                        Fill="{ThemeResource DividerStrokeColorDefaultBrush}"/>
                 </Grid>
                 <RelativePanel Grid.Row="1" x:Name="Container"/>
 

--- a/CelestiaWinUI/SettingsUserControl.xaml
+++ b/CelestiaWinUI/SettingsUserControl.xaml
@@ -57,25 +57,30 @@
             MenuItemTemplate="{StaticResource ItemGroupTemplate}"
             DisplayModeChanged="NavigationView_DisplayModeChanged"
             SelectionChanged="NavigationView_SelectionChanged">
-            <Grid x:Name="PageLayout" Margin="36,24,36,0" MaxWidth="1064" HorizontalAlignment="Stretch">
+            <Grid x:Name="PageLayout">
                 <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="*"/>
                 </Grid.RowDefinitions>
 
-                <TextBlock
-                    x:Name="PageTitle"
-                    Style="{StaticResource TitleTextBlockStyle}"
-                    FontSize="28"
-                    FontWeight="SemiBold"
-                    AutomationProperties.HeadingLevel="Level1"/>
-                <Rectangle
-                    Grid.Row="1"
-                    Height="1"
-                    Margin="0,12,0,0"
-                    Fill="{ThemeResource DividerStrokeColorDefaultBrush}"/>
-                <RelativePanel Grid.Row="2" x:Name="Container"/>
+                <Grid x:Name="HeaderLayout" Margin="36,24,36,0" MaxWidth="1064" HorizontalAlignment="Stretch">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+                    <TextBlock
+                        x:Name="PageTitle"
+                        Style="{StaticResource TitleTextBlockStyle}"
+                        FontSize="28"
+                        FontWeight="SemiBold"
+                        AutomationProperties.HeadingLevel="Level1"/>
+                    <Rectangle
+                        Grid.Row="1"
+                        Height="1"
+                        Margin="0,12,0,0"
+                        Fill="{ThemeResource DividerStrokeColorDefaultBrush}"/>
+                </Grid>
+                <RelativePanel Grid.Row="1" x:Name="Container"/>
 
                 <VisualStateManager.VisualStateGroups>
                     <VisualStateGroup>
@@ -84,7 +89,7 @@
                                 <AdaptiveTrigger MinWindowWidth="0"/>
                             </VisualState.StateTriggers>
                             <VisualState.Setters>
-                                <Setter Target="PageLayout.Margin" Value="20,16,20,0"/>
+                                <Setter Target="HeaderLayout.Margin" Value="20,16,20,0"/>
                             </VisualState.Setters>
                         </VisualState>
                         <VisualState x:Name="WideLayout">
@@ -92,7 +97,7 @@
                                 <AdaptiveTrigger MinWindowWidth="700"/>
                             </VisualState.StateTriggers>
                             <VisualState.Setters>
-                                <Setter Target="PageLayout.Margin" Value="36,24,36,0"/>
+                                <Setter Target="HeaderLayout.Margin" Value="36,24,36,0"/>
                             </VisualState.Setters>
                         </VisualState>
                     </VisualStateGroup>

--- a/CelestiaWinUI/SettingsUserControl.xaml
+++ b/CelestiaWinUI/SettingsUserControl.xaml
@@ -9,65 +9,95 @@
 
     <UserControl.Resources>
         <DataTemplate x:Key="ItemGroupTemplate" x:DataType="local:SettingsNavigationItemGroup">
-            <NavigationViewItem Content="{x:Bind Title}">
-                <NavigationViewItem.Icon>
-                    <SymbolIcon Symbol="Setting"/>
-                </NavigationViewItem.Icon>
-            </NavigationViewItem>
+            <NavigationViewItem Content="{x:Bind Title}"/>
         </DataTemplate>
     </UserControl.Resources>
-    <NavigationView
-        x:Name="Nav"
-        IsBackButtonVisible="Collapsed"
-        IsSettingsVisible="False"
-        IsTitleBarAutoPaddingEnabled="False"
-        CompactModeThresholdWidth="900"
-        ExpandedModeThresholdWidth="900"
-        OpenPaneLength="240"
-        PaneDisplayMode="Auto"
-        MenuItemsSource="{x:Bind ItemGroups, Mode=OneWay}"
-        MenuItemTemplate="{StaticResource ItemGroupTemplate}"
-        SelectionChanged="NavigationView_SelectionChanged">
-        <Grid x:Name="PageLayout" Margin="36,24,36,0" MaxWidth="1064" HorizontalAlignment="Stretch">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="*"/>
-            </Grid.RowDefinitions>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="48"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
 
+        <Grid Grid.Row="0">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+            <Button
+                x:Name="PaneToggleButton"
+                Width="48"
+                Height="48"
+                Padding="0"
+                Background="Transparent"
+                BorderThickness="0"
+                Click="PaneToggleButton_Click">
+                <FontIcon Glyph="&#xE700;"/>
+            </Button>
             <TextBlock
-                x:Name="PageTitle"
-                Style="{StaticResource TitleTextBlockStyle}"
-                FontSize="28"
-                FontWeight="SemiBold"
-                AutomationProperties.HeadingLevel="Level1"/>
-            <Rectangle
-                Grid.Row="1"
-                Height="1"
-                Margin="0,12,0,20"
-                Fill="{ThemeResource DividerStrokeColorDefaultBrush}"/>
-            <RelativePanel Grid.Row="2" x:Name="Container"/>
-
-            <VisualStateManager.VisualStateGroups>
-                <VisualStateGroup>
-                    <VisualState x:Name="NarrowLayout">
-                        <VisualState.StateTriggers>
-                            <AdaptiveTrigger MinWindowWidth="0"/>
-                        </VisualState.StateTriggers>
-                        <VisualState.Setters>
-                            <Setter Target="PageLayout.Margin" Value="20,16,20,0"/>
-                        </VisualState.Setters>
-                    </VisualState>
-                    <VisualState x:Name="WideLayout">
-                        <VisualState.StateTriggers>
-                            <AdaptiveTrigger MinWindowWidth="700"/>
-                        </VisualState.StateTriggers>
-                        <VisualState.Setters>
-                            <Setter Target="PageLayout.Margin" Value="36,24,36,0"/>
-                        </VisualState.Setters>
-                    </VisualState>
-                </VisualStateGroup>
-            </VisualStateManager.VisualStateGroups>
+                x:Name="WindowTitle"
+                Grid.Column="1"
+                Margin="12,0"
+                VerticalAlignment="Center"/>
+            <Grid x:Name="TitleBarDragRegion" Grid.Column="2" Background="Transparent"/>
         </Grid>
-    </NavigationView>
+
+        <NavigationView
+            x:Name="Nav"
+            Grid.Row="1"
+            IsBackButtonVisible="Collapsed"
+            IsPaneToggleButtonVisible="False"
+            IsSettingsVisible="False"
+            IsTitleBarAutoPaddingEnabled="False"
+            CompactModeThresholdWidth="700"
+            ExpandedModeThresholdWidth="700"
+            OpenPaneLength="240"
+            PaneDisplayMode="Auto"
+            MenuItemsSource="{x:Bind ItemGroups, Mode=OneWay}"
+            MenuItemTemplate="{StaticResource ItemGroupTemplate}"
+            DisplayModeChanged="NavigationView_DisplayModeChanged"
+            SelectionChanged="NavigationView_SelectionChanged">
+            <Grid x:Name="PageLayout" Margin="36,24,36,0" MaxWidth="1064" HorizontalAlignment="Stretch">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+
+                <TextBlock
+                    x:Name="PageTitle"
+                    Style="{StaticResource TitleTextBlockStyle}"
+                    FontSize="28"
+                    FontWeight="SemiBold"
+                    AutomationProperties.HeadingLevel="Level1"/>
+                <Rectangle
+                    Grid.Row="1"
+                    Height="1"
+                    Margin="0,12,0,0"
+                    Fill="{ThemeResource DividerStrokeColorDefaultBrush}"/>
+                <RelativePanel Grid.Row="2" x:Name="Container"/>
+
+                <VisualStateManager.VisualStateGroups>
+                    <VisualStateGroup>
+                        <VisualState x:Name="NarrowLayout">
+                            <VisualState.StateTriggers>
+                                <AdaptiveTrigger MinWindowWidth="0"/>
+                            </VisualState.StateTriggers>
+                            <VisualState.Setters>
+                                <Setter Target="PageLayout.Margin" Value="20,16,20,0"/>
+                            </VisualState.Setters>
+                        </VisualState>
+                        <VisualState x:Name="WideLayout">
+                            <VisualState.StateTriggers>
+                                <AdaptiveTrigger MinWindowWidth="700"/>
+                            </VisualState.StateTriggers>
+                            <VisualState.Setters>
+                                <Setter Target="PageLayout.Margin" Value="36,24,36,0"/>
+                            </VisualState.Setters>
+                        </VisualState>
+                    </VisualStateGroup>
+                </VisualStateManager.VisualStateGroups>
+            </Grid>
+        </NavigationView>
+    </Grid>
 </UserControl>

--- a/CelestiaWinUI/SettingsUserControl.xaml
+++ b/CelestiaWinUI/SettingsUserControl.xaml
@@ -9,10 +9,65 @@
 
     <UserControl.Resources>
         <DataTemplate x:Key="ItemGroupTemplate" x:DataType="local:SettingsNavigationItemGroup">
-            <NavigationViewItem Content="{x:Bind Title}"/>
+            <NavigationViewItem Content="{x:Bind Title}">
+                <NavigationViewItem.Icon>
+                    <SymbolIcon Symbol="Setting"/>
+                </NavigationViewItem.Icon>
+            </NavigationViewItem>
         </DataTemplate>
     </UserControl.Resources>
-    <NavigationView MenuItemsSource="{x:Bind ItemGroups, Mode=OneWay}" MenuItemTemplate="{StaticResource ItemGroupTemplate}" SelectionChanged="NavigationView_SelectionChanged" x:Name="Nav" IsSettingsVisible="False" IsBackButtonVisible="Collapsed" PaneDisplayMode="Top">
-        <RelativePanel x:Name="Container"/>
+    <NavigationView
+        x:Name="Nav"
+        IsBackButtonVisible="Collapsed"
+        IsSettingsVisible="False"
+        IsTitleBarAutoPaddingEnabled="False"
+        CompactModeThresholdWidth="900"
+        ExpandedModeThresholdWidth="900"
+        OpenPaneLength="240"
+        PaneDisplayMode="Auto"
+        MenuItemsSource="{x:Bind ItemGroups, Mode=OneWay}"
+        MenuItemTemplate="{StaticResource ItemGroupTemplate}"
+        SelectionChanged="NavigationView_SelectionChanged">
+        <Grid x:Name="PageLayout" Margin="36,24,36,0" MaxWidth="1064" HorizontalAlignment="Stretch">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+            </Grid.RowDefinitions>
+
+            <TextBlock
+                x:Name="PageTitle"
+                Style="{StaticResource TitleTextBlockStyle}"
+                FontSize="28"
+                FontWeight="SemiBold"
+                AutomationProperties.HeadingLevel="Level1"/>
+            <Rectangle
+                Grid.Row="1"
+                Height="1"
+                Margin="0,12,0,20"
+                Fill="{ThemeResource DividerStrokeColorDefaultBrush}"/>
+            <RelativePanel Grid.Row="2" x:Name="Container"/>
+
+            <VisualStateManager.VisualStateGroups>
+                <VisualStateGroup>
+                    <VisualState x:Name="NarrowLayout">
+                        <VisualState.StateTriggers>
+                            <AdaptiveTrigger MinWindowWidth="0"/>
+                        </VisualState.StateTriggers>
+                        <VisualState.Setters>
+                            <Setter Target="PageLayout.Margin" Value="20,16,20,0"/>
+                        </VisualState.Setters>
+                    </VisualState>
+                    <VisualState x:Name="WideLayout">
+                        <VisualState.StateTriggers>
+                            <AdaptiveTrigger MinWindowWidth="700"/>
+                        </VisualState.StateTriggers>
+                        <VisualState.Setters>
+                            <Setter Target="PageLayout.Margin" Value="36,24,36,0"/>
+                        </VisualState.Setters>
+                    </VisualState>
+                </VisualStateGroup>
+            </VisualStateManager.VisualStateGroups>
+        </Grid>
     </NavigationView>
 </UserControl>

--- a/CelestiaWinUI/SettingsUserControl.xaml
+++ b/CelestiaWinUI/SettingsUserControl.xaml
@@ -9,7 +9,11 @@
 
     <UserControl.Resources>
         <DataTemplate x:Key="ItemGroupTemplate" x:DataType="local:SettingsNavigationItemGroup">
-            <NavigationViewItem Content="{x:Bind Title}"/>
+            <NavigationViewItem Content="{x:Bind Title}">
+                <NavigationViewItem.Icon>
+                    <SymbolIcon Symbol="{x:Bind Icon}"/>
+                </NavigationViewItem.Icon>
+            </NavigationViewItem>
         </DataTemplate>
     </UserControl.Resources>
     <Grid>

--- a/CelestiaWinUI/SettingsUserControl.xaml.cpp
+++ b/CelestiaWinUI/SettingsUserControl.xaml.cpp
@@ -441,12 +441,22 @@ namespace winrt::CelestiaWinUI::implementation
     void SettingsUserControl::InitializeComponent()
     {
         SettingsUserControlT::InitializeComponent();
+        WindowTitle().Text(LocalizationHelper::Localize(L"Settings", L""));
+        auto navigationTitle = LocalizationHelper::Localize(L"Navigation", L"Navigation menu");
+        Automation::AutomationProperties::SetName(PaneToggleButton(), navigationTitle);
+        ToolTipService::SetToolTip(PaneToggleButton(), box_value(navigationTitle));
+        PaneToggleButton().Visibility(Nav().DisplayMode() == NavigationViewDisplayMode::Expanded ? Visibility::Collapsed : Visibility::Visible);
         Nav().SelectedItem(itemGroups.GetAt(0));
     }
 
     Collections::IObservableVector<CelestiaWinUI::SettingsNavigationItemGroup> SettingsUserControl::ItemGroups()
     {
         return itemGroups;
+    }
+
+    UIElement SettingsUserControl::TitleBarElement()
+    {
+        return TitleBarDragRegion();
     }
 
     void SettingsUserControl::NavigationView_SelectionChanged(IInspectable const&, NavigationViewSelectionChangedEventArgs const& args)
@@ -456,6 +466,16 @@ namespace winrt::CelestiaWinUI::implementation
         auto itemGroup = selectedItem.try_as<CelestiaWinUI::SettingsNavigationItemGroup>();
         if (itemGroup == nullptr) return;
         ItemGroupSelected(itemGroup);
+    }
+
+    void SettingsUserControl::NavigationView_DisplayModeChanged(NavigationView const&, NavigationViewDisplayModeChangedEventArgs const& args)
+    {
+        PaneToggleButton().Visibility(args.DisplayMode() == NavigationViewDisplayMode::Expanded ? Visibility::Collapsed : Visibility::Visible);
+    }
+
+    void SettingsUserControl::PaneToggleButton_Click(IInspectable const&, RoutedEventArgs const&)
+    {
+        Nav().IsPaneOpen(!Nav().IsPaneOpen());
     }
 
     void SettingsUserControl::ItemGroupSelected(CelestiaWinUI::SettingsNavigationItemGroup const& itemGroup)

--- a/CelestiaWinUI/SettingsUserControl.xaml.cpp
+++ b/CelestiaWinUI/SettingsUserControl.xaml.cpp
@@ -8,6 +8,7 @@
 // of the License, or (at your option) any later version.
 
 #include "pch.h"
+#include <winrt/Microsoft.UI.Xaml.Automation.h>
 #include "SettingsUserControl.xaml.h"
 #if __has_include("SettingsUserControl.g.cpp")
 #include "SettingsUserControl.g.cpp"

--- a/CelestiaWinUI/SettingsUserControl.xaml.cpp
+++ b/CelestiaWinUI/SettingsUserControl.xaml.cpp
@@ -45,11 +45,16 @@ namespace
 
 namespace winrt::CelestiaWinUI::implementation
 {
-    SettingsNavigationItemGroup::SettingsNavigationItemGroup(hstring const& title, Collections::IObservableVector<IInspectable> const& items, bool showRestartHint) : title(title), items(items), showRestartHint(showRestartHint) {};
+    SettingsNavigationItemGroup::SettingsNavigationItemGroup(hstring const& title, Symbol icon, Collections::IObservableVector<IInspectable> const& items, bool showRestartHint) : title(title), icon(icon), items(items), showRestartHint(showRestartHint) {};
 
     hstring SettingsNavigationItemGroup::Title()
     {
         return title;
+    }
+
+    Symbol SettingsNavigationItemGroup::Icon()
+    {
+        return icon;
     }
 
     Collections::IObservableVector<IInspectable> SettingsNavigationItemGroup::Items()
@@ -92,7 +97,7 @@ namespace winrt::CelestiaWinUI::implementation
         };
         auto displaySettingItemGroupItems = single_threaded_observable_vector<IInspectable>();
         displaySettingItemGroupItems.ReplaceAll(displaySettingItems);
-        itemGroups.Append(CelestiaWinUI::SettingsNavigationItemGroup(LocalizationHelper::Localize(L"Display", L"Display settings"), displaySettingItemGroupItems, false));
+        itemGroups.Append(CelestiaWinUI::SettingsNavigationItemGroup(LocalizationHelper::Localize(L"Display", L"Display settings"), Symbol::View, displaySettingItemGroupItems, false));
 
         std::vector<IInspectable> guidesSettingItems =
         {
@@ -131,7 +136,7 @@ namespace winrt::CelestiaWinUI::implementation
         };
         auto guidesSettingItemGroupItems = single_threaded_observable_vector<IInspectable>();
         guidesSettingItemGroupItems.ReplaceAll(guidesSettingItems);
-        itemGroups.Append(CelestiaWinUI::SettingsNavigationItemGroup(LocalizationHelper::Localize(L"Guides", L"Grids, labels, orbits, markers"), guidesSettingItemGroupItems, false));
+        itemGroups.Append(CelestiaWinUI::SettingsNavigationItemGroup(LocalizationHelper::Localize(L"Guides", L"Grids, labels, orbits, markers"), Symbol::Map, guidesSettingItemGroupItems, false));
 
         std::vector<IInspectable> labelsSettingItems =
         {
@@ -220,7 +225,7 @@ namespace winrt::CelestiaWinUI::implementation
         };
         auto labelsSettingItemGroupItems = single_threaded_observable_vector<IInspectable>();
         labelsSettingItemGroupItems.ReplaceAll(labelsSettingItems);
-        itemGroups.Append(CelestiaWinUI::SettingsNavigationItemGroup(LocalizationHelper::Localize(L"Labels", L"Labels to display"), labelsSettingItemGroupItems, false));
+        itemGroups.Append(CelestiaWinUI::SettingsNavigationItemGroup(LocalizationHelper::Localize(L"Labels", L"Labels to display"), Symbol::Font, labelsSettingItemGroupItems, false));
 
         Windows::Globalization::NumberFormatting::DecimalFormatter shadowMapSizeFormatter;
         shadowMapSizeFormatter.IsGrouped(true);
@@ -307,7 +312,7 @@ namespace winrt::CelestiaWinUI::implementation
 
         auto rendererSettingItemGroupItems = single_threaded_observable_vector<IInspectable>();
         rendererSettingItemGroupItems.ReplaceAll(rendererSettingItems);
-        itemGroups.Append(CelestiaWinUI::SettingsNavigationItemGroup(LocalizationHelper::Localize(L"Renderer", L"In settings"), rendererSettingItemGroupItems, true));
+        itemGroups.Append(CelestiaWinUI::SettingsNavigationItemGroup(LocalizationHelper::Localize(L"Renderer", L"In settings"), Symbol::Pictures, rendererSettingItemGroupItems, true));
 
         std::vector<IInspectable> regionSettingItems =
         {
@@ -350,7 +355,7 @@ namespace winrt::CelestiaWinUI::implementation
 
         auto regionSettingItemGroupItems = single_threaded_observable_vector<IInspectable>();
         regionSettingItemGroupItems.ReplaceAll(regionSettingItems);
-        itemGroups.Append(CelestiaWinUI::SettingsNavigationItemGroup(LocalizationHelper::Localize(L"Time & Region", L"time and region related settings"), regionSettingItemGroupItems, true));
+        itemGroups.Append(CelestiaWinUI::SettingsNavigationItemGroup(LocalizationHelper::Localize(L"Time & Region", L"time and region related settings"), Symbol::Clock, regionSettingItemGroupItems, true));
 
         auto interactionSettingItemGroupItems = single_threaded_observable_vector<IInspectable>();
         interactionSettingItemGroupItems.ReplaceAll(std::vector<IInspectable>
@@ -365,14 +370,14 @@ namespace winrt::CelestiaWinUI::implementation
             AppSettingsBooleanItem(LocalizationHelper::Localize(L"Hide Cursor During Dragging", L""), appSettings, AppSettingBooleanEntry::HideCursorDuringDragging, localSettings, LocalizationHelper::Localize(L"Hide the mouse cursor during dragging", L"")),
             AppSettingsBooleanItem(LocalizationHelper::Localize(L"Infinite Dragging", L""), appSettings, AppSettingBooleanEntry::InfiniteDragging, localSettings, LocalizationHelper::Localize(L"Mouse cursor is warped to the location when the dragging starts. Only effective when the cursor is hidden during dragging", L"")),
         });
-        itemGroups.Append(CelestiaWinUI::SettingsNavigationItemGroup(LocalizationHelper::Localize(L"Interaction", L"Settings for interaction"), interactionSettingItemGroupItems, true));
+        itemGroups.Append(CelestiaWinUI::SettingsNavigationItemGroup(LocalizationHelper::Localize(L"Interaction", L"Settings for interaction"), Symbol::TouchPointer, interactionSettingItemGroupItems, true));
 
         auto cameraSettingItemGroupItems = single_threaded_observable_vector<IInspectable>();
         cameraSettingItemGroupItems.ReplaceAll(std::vector<IInspectable>
         {
             AppCoreBooleanItem(LocalizationHelper::Localize(L"Align to Surface on Landing", L"Option to align camera to surface when landing"), appCore, renderer, CelestiaComponent::CelestiaSettingBooleanEntry::EnableAlignCameraToSurfaceOnLand, localSettings),
         });
-        itemGroups.Append(CelestiaWinUI::SettingsNavigationItemGroup(LocalizationHelper::Localize(L"Camera", L"Settings for camera control"), cameraSettingItemGroupItems, true));
+        itemGroups.Append(CelestiaWinUI::SettingsNavigationItemGroup(LocalizationHelper::Localize(L"Camera", L"Settings for camera control"), Symbol::Camera, cameraSettingItemGroupItems, true));
 
         auto allActions = single_threaded_vector<OptionPair>
             ({
@@ -415,7 +420,7 @@ namespace winrt::CelestiaWinUI::implementation
                 AppSettingsBooleanItem(LocalizationHelper::Localize(L"Invert Horizontally", L"Invert game controller thumbstick axis horizontally"), appSettings, AppSettingBooleanEntry::GamepadInvertX, localSettings),
                 AppSettingsBooleanItem(LocalizationHelper::Localize(L"Invert Vertically", L"Invert game controller thumbstick axis vertically"), appSettings, AppSettingBooleanEntry::GamepadInvertY, localSettings),
             });
-        itemGroups.Append(CelestiaWinUI::SettingsNavigationItemGroup(LocalizationHelper::Localize(L"Game Controller", L"Settings for game controller"), gamepadSettingItemGroupItems, false));
+        itemGroups.Append(CelestiaWinUI::SettingsNavigationItemGroup(LocalizationHelper::Localize(L"Game Controller", L"Settings for game controller"), Symbol::XboxOneConsole, gamepadSettingItemGroupItems, false));
 
         auto dataLocationSettingItemGroupItems = single_threaded_observable_vector<IInspectable>();
         dataLocationSettingItemGroupItems.ReplaceAll(std::vector<IInspectable>
@@ -423,7 +428,7 @@ namespace winrt::CelestiaWinUI::implementation
             SettingDataDirectoryItem(appSettings, localSettings),
             SettingConfigFileItem(appSettings, localSettings),
         });
-        itemGroups.Append(CelestiaWinUI::SettingsNavigationItemGroup(LocalizationHelper::Localize(L"Data Location", L"Title for celestia.cfg, data location setting"), dataLocationSettingItemGroupItems, true));
+        itemGroups.Append(CelestiaWinUI::SettingsNavigationItemGroup(LocalizationHelper::Localize(L"Data Location", L"Title for celestia.cfg, data location setting"), Symbol::Folder, dataLocationSettingItemGroupItems, true));
 
         auto advancedSettingItemGroupItems = single_threaded_observable_vector<IInspectable>();
         advancedSettingItemGroupItems.ReplaceAll(std::vector<IInspectable>
@@ -436,7 +441,7 @@ namespace winrt::CelestiaWinUI::implementation
                 OptionPair(2, LocalizationHelper::Localize(L"Deny", L"Script system access policy option"))
             }), localSettings, LocalizationHelper::Localize(L"Lua scripts' access to the file system", L"Note for Script System Access Policy")),
         });
-        itemGroups.Append(CelestiaWinUI::SettingsNavigationItemGroup(LocalizationHelper::Localize(L"Advanced", L"Advanced setting items"), advancedSettingItemGroupItems, false));
+        itemGroups.Append(CelestiaWinUI::SettingsNavigationItemGroup(LocalizationHelper::Localize(L"Advanced", L"Advanced setting items"), Symbol::Admin, advancedSettingItemGroupItems, false));
     }
 
     void SettingsUserControl::InitializeComponent()

--- a/CelestiaWinUI/SettingsUserControl.xaml.cpp
+++ b/CelestiaWinUI/SettingsUserControl.xaml.cpp
@@ -97,8 +97,10 @@ namespace winrt::CelestiaWinUI::implementation
         {
              SettingHeaderItem(LocalizationHelper::Localize(L"Orbits", L"")),
              AppCoreBooleanItem(LocalizationHelper::Localize(L"Show Orbits", L""), appCore, renderer, CelestiaComponent::CelestiaSettingBooleanEntry::ShowOrbits, localSettings),
+             CelestiaWinUI::SettingGroupSeparator(),
              AppCoreBooleanItem(LocalizationHelper::Localize(L"Fading Orbits", L""), appCore, renderer, CelestiaComponent::CelestiaSettingBooleanEntry::ShowFadingOrbits, localSettings),
              AppCoreBooleanItem(LocalizationHelper::Localize(L"Partial Trajectories", L""), appCore, renderer, CelestiaComponent::CelestiaSettingBooleanEntry::ShowPartialTrajectories, localSettings),
+             CelestiaWinUI::SettingGroupSeparator(),
              AppCoreBooleanItem(LocalizationHelper::Localize(L"Stars", L"Tab for stars in Star Browser"), appCore, renderer, CelestiaComponent::CelestiaSettingBooleanEntry::ShowStellarOrbits, localSettings),
              AppCoreBooleanItem(LocalizationHelper::Localize(L"Planets", L""), appCore, renderer, CelestiaComponent::CelestiaSettingBooleanEntry::ShowPlanetOrbits, localSettings),
              AppCoreBooleanItem(LocalizationHelper::Localize(L"Dwarf Planets", L""), appCore, renderer, CelestiaComponent::CelestiaSettingBooleanEntry::ShowDwarfPlanetOrbits, localSettings),
@@ -110,8 +112,10 @@ namespace winrt::CelestiaWinUI::implementation
 
              SettingHeaderItem(LocalizationHelper::Localize(L"Constellations", L"")),
              AppCoreBooleanItem(LocalizationHelper::Localize(L"Show Diagrams", L"Show constellation diagrams"), appCore, renderer, CelestiaComponent::CelestiaSettingBooleanEntry::ShowDiagrams, localSettings),
+             CelestiaWinUI::SettingGroupSeparator(),
              AppCoreBooleanItem(LocalizationHelper::Localize(L"Show Labels", L"Constellation labels"), appCore, renderer, CelestiaComponent::CelestiaSettingBooleanEntry::ShowConstellationLabels, localSettings),
              AppCoreBooleanItem(LocalizationHelper::Localize(L"Show Labels in Latin", L"Constellation labels in Latin"), appCore, renderer, CelestiaComponent::CelestiaSettingBooleanEntry::ShowLatinConstellationLabels, localSettings),
+             CelestiaWinUI::SettingGroupSeparator(),
              AppCoreBooleanItem(LocalizationHelper::Localize(L"Show Boundaries", L"Show constellation boundaries"), appCore, renderer, CelestiaComponent::CelestiaSettingBooleanEntry::ShowBoundaries, localSettings),
 
              SettingHeaderItem(LocalizationHelper::Localize(L"Grids", L"")),
@@ -146,7 +150,9 @@ namespace winrt::CelestiaWinUI::implementation
 
             SettingHeaderItem(LocalizationHelper::Localize(L"Locations", L"Location labels to display")),
             AppCoreBooleanItem(LocalizationHelper::Localize(L"Show Locations", L""), appCore, renderer, CelestiaComponent::CelestiaSettingBooleanEntry::ShowLocationLabels, localSettings),
+            CelestiaWinUI::SettingGroupSeparator(),
             AppCoreSingleItem(LocalizationHelper::Localize(L"Minimum Labeled Feature Size", L"Minimum feature size that we should display a label for"), appCore, renderer, CelestiaComponent::CelestiaSettingSingleEntry::MinimumFeatureSize, 0.0f, 99.0f, 1.0f, localSettings),
+            CelestiaWinUI::SettingGroupSeparator(),
             AppCoreBooleanItem(LocalizationHelper::Localize(L"Cities", L""), appCore, renderer, CelestiaComponent::CelestiaSettingBooleanEntry::ShowCityLabels, localSettings),
             AppCoreBooleanItem(LocalizationHelper::Localize(L"Observatories", L"Location labels"), appCore, renderer, CelestiaComponent::CelestiaSettingBooleanEntry::ShowObservatoryLabels, localSettings),
             AppCoreBooleanItem(LocalizationHelper::Localize(L"Landing Sites", L"Location labels"), appCore, renderer, CelestiaComponent::CelestiaSettingBooleanEntry::ShowLandingSiteLabels, localSettings),
@@ -249,6 +255,7 @@ namespace winrt::CelestiaWinUI::implementation
                 OptionPair(1, LocalizationHelper::Localize(L"Medium", L"Medium resolution")),
                 OptionPair(2, LocalizationHelper::Localize(L"High", L"High resolution"))
             }), localSettings),
+            CelestiaWinUI::SettingGroupSeparator(),
             AppCoreInt32Item(LocalizationHelper::Localize(L"Star Style", L""), appCore, renderer, CelestiaComponent::CelestiaSettingInt32Entry::StarStyle, single_threaded_vector<OptionPair>
             ({
                 OptionPair(0, LocalizationHelper::Localize(L"Fuzzy Points", L"Star style")),
@@ -264,19 +271,24 @@ namespace winrt::CelestiaWinUI::implementation
                 OptionPair(3, LocalizationHelper::Localize(L"Blackbody (Vega Whitepoint)", L"Star colors option")),
             }), localSettings),
             AppCoreSingleItem(LocalizationHelper::Localize(L"Tinted Illumination Saturation", L""), appCore, renderer, CelestiaComponent::CelestiaSettingSingleEntry::TintSaturation, 0.0f, 1.0f, 0.01f, localSettings, LocalizationHelper::Localize(L"Tinted illumination saturation setting is only effective with Blackbody star colors.", L"")),
+
+            CelestiaWinUI::SettingGroupSeparator(),
+            AppCoreBooleanItem(LocalizationHelper::Localize(L"Auto Mag", L"Auto mag for star display"), appCore, renderer, CelestiaComponent::CelestiaSettingBooleanEntry::ShowAutoMag, localSettings),
+            AppCoreSingleItem(LocalizationHelper::Localize(L"Faintest Stars", L"Control the faintest star that Celestia should display"), appCore, renderer, CelestiaComponent::CelestiaSettingSingleEntry::FaintestVisible, 3.0f, 12.0f, 1.0f, localSettings),
+
+            CelestiaWinUI::SettingGroupSeparator(),
+            AppCoreSingleItem(LocalizationHelper::Localize(L"Ambient Light", L"In setting"), appCore, renderer, CelestiaComponent::CelestiaSettingSingleEntry::AmbientLightLevel, 0.0f, 0.99f, 0.01f, localSettings),
+            AppCoreSingleItem(LocalizationHelper::Localize(L"Galaxy Brightness", L"Render parameter"), appCore, renderer, CelestiaComponent::CelestiaSettingSingleEntry::GalaxyBrightness, 0.0f, 1.0f, 0.01f, localSettings),
+
+            CelestiaWinUI::SettingGroupSeparator(),
+            AppCoreBooleanItem(LocalizationHelper::Localize(L"Smooth Lines", L"Smooth lines for rendering"), appCore, renderer, CelestiaComponent::CelestiaSettingBooleanEntry::ShowSmoothLines, localSettings),
+
             SettingHeaderItem(LocalizationHelper::Localize(L"Point Spread Function", L"Star style"), LocalizationHelper::Localize(L"Point spread function settings are only effective with the Point Spread Function star style.", L"")),
             AppCoreSingleItem(LocalizationHelper::Localize(L"Point Radius", L"PSF star setting"), appCore, renderer, CelestiaComponent::CelestiaSettingSingleEntry::StarPointRadius, 1.0f, 10.0f, 0.5f, localSettings, LocalizationHelper::Localize(L"Pixel radius of a unit-irradiance star sprite.", L"PSF star setting footnote")),
             AppCoreSingleItem(LocalizationHelper::Localize(L"Bloom Compactness", L"PSF star setting"), appCore, renderer, CelestiaComponent::CelestiaSettingSingleEntry::StarOptimization, 0.05f, 1.0f, 0.05f, localSettings, LocalizationHelper::Localize(L"Extent of the eye PSF glow around bright stars. Lower values widen the glow at higher GPU cost.", L"PSF star setting footnote")),
             AppCoreSingleItem(LocalizationHelper::Localize(L"Max Irradiance", L"PSF star setting"), appCore, renderer, CelestiaComponent::CelestiaSettingSingleEntry::StarMaxIrradiance, 1.0f, 1000000.0f, 10.0f, localSettings, LocalizationHelper::Localize(L"Soft upper limit on per-star peak irradiance to prevent bloom saturation.", L"PSF star setting footnote"), true),
             AppCoreSingleItem(LocalizationHelper::Localize(L"Dim Clip Factor", L"PSF star setting"), appCore, renderer, CelestiaComponent::CelestiaSettingSingleEntry::StarDimClipFactor, 1.0f, 100.0f, 1.0f, localSettings, LocalizationHelper::Localize(L"Soft-clips dim stars below this multiple of the perceptual visibility floor.", L"PSF star setting footnote")),
             AppCoreSingleItem(LocalizationHelper::Localize(L"Exposure", L"PSF star setting"), appCore, renderer, CelestiaComponent::CelestiaSettingSingleEntry::StarExposure, 0.01f, 1000000.0f, 1.0f, localSettings, LocalizationHelper::Localize(L"Brightness multiplier applied to every star, extending the visible magnitude limit.", L"PSF star setting footnote"), true),
-
-            AppCoreBooleanItem(LocalizationHelper::Localize(L"Smooth Lines", L"Smooth lines for rendering"), appCore, renderer, CelestiaComponent::CelestiaSettingBooleanEntry::ShowSmoothLines, localSettings),
-
-            AppCoreBooleanItem(LocalizationHelper::Localize(L"Auto Mag", L"Auto mag for star display"), appCore, renderer, CelestiaComponent::CelestiaSettingBooleanEntry::ShowAutoMag, localSettings),
-            AppCoreSingleItem(LocalizationHelper::Localize(L"Ambient Light", L"In setting"), appCore, renderer, CelestiaComponent::CelestiaSettingSingleEntry::AmbientLightLevel, 0.0f, 0.99f, 0.01f, localSettings),
-            AppCoreSingleItem(LocalizationHelper::Localize(L"Faintest Stars", L"Control the faintest star that Celestia should display"), appCore, renderer, CelestiaComponent::CelestiaSettingSingleEntry::FaintestVisible, 3.0f, 12.0f, 1.0f, localSettings),
-            AppCoreSingleItem(LocalizationHelper::Localize(L"Galaxy Brightness", L"Render parameter"), appCore, renderer, CelestiaComponent::CelestiaSettingSingleEntry::GalaxyBrightness, 0.0f, 1.0f, 0.01f, localSettings),
 
             SettingHeaderItem(LocalizationHelper::Localize(L"Output Rendering", L""), LocalizationHelper::Localize(L"Changes to sRGB rendering take effect after a restart.", L"Output rendering settings footnote")),
             srgbRenderingItem,
@@ -331,6 +343,7 @@ namespace winrt::CelestiaWinUI::implementation
                 OptionPair(1, LocalizationHelper::Localize(L"Celsius", L"Temperature scale")),
                 OptionPair(2, LocalizationHelper::Localize(L"Fahrenheit", L"Temperature scale"))
             }), localSettings),
+            CelestiaWinUI::SettingGroupSeparator(),
             LanguageInt32Item(LocalizationHelper::Localize(L"Language", L"Display language setting"), appSettings, availableLanguages, localSettings),
         };
 
@@ -342,9 +355,12 @@ namespace winrt::CelestiaWinUI::implementation
         interactionSettingItemGroupItems.ReplaceAll(std::vector<IInspectable>
         {
             AppCoreBooleanItem(LocalizationHelper::Localize(L"Reverse Mouse Wheel", L""), appCore, renderer, CelestiaComponent::CelestiaSettingBooleanEntry::EnableReverseWheel, localSettings),
+            CelestiaWinUI::SettingGroupSeparator(),
             AppCoreBooleanItem(LocalizationHelper::Localize(L"Ray-Based Dragging", L""), appCore, renderer, CelestiaComponent::CelestiaSettingBooleanEntry::EnableRayBasedDragging, localSettings, LocalizationHelper::Localize(L"Dragging behavior based on change of pick rays instead of screen coordinates", L"")),
             AppCoreBooleanItem(LocalizationHelper::Localize(L"Focus Zooming", L""), appCore, renderer, CelestiaComponent::CelestiaSettingBooleanEntry::EnableFocusZooming, localSettings, LocalizationHelper::Localize(L"Zooming behavior keeping the original focus location on screen", L"")),
+            CelestiaWinUI::SettingGroupSeparator(),
             AppSettingsDoubleItem(LocalizationHelper::Localize(L"Sensitivity", L"Setting for sensitivity for selecting an object"), appSettings, AppSettingDoubleEntry::PickSensitivity, 1.0, 20.0, 1.0, localSettings, LocalizationHelper::Localize(L"Sensitivity for object selection", L"Notes for the sensitivity setting")),
+            CelestiaWinUI::SettingGroupSeparator(),
             AppSettingsBooleanItem(LocalizationHelper::Localize(L"Hide Cursor During Dragging", L""), appSettings, AppSettingBooleanEntry::HideCursorDuringDragging, localSettings, LocalizationHelper::Localize(L"Hide the mouse cursor during dragging", L"")),
             AppSettingsBooleanItem(LocalizationHelper::Localize(L"Infinite Dragging", L""), appSettings, AppSettingBooleanEntry::InfiniteDragging, localSettings, LocalizationHelper::Localize(L"Mouse cursor is warped to the location when the dragging starts. Only effective when the cursor is hidden during dragging", L"")),
         });
@@ -394,6 +410,7 @@ namespace winrt::CelestiaWinUI::implementation
                 SettingHeaderItem(LocalizationHelper::Localize(L"Thumbsticks", L"Settings for game controller thumbsticks")),
                 AppSettingsBooleanItem(LocalizationHelper::Localize(L"Enable Left Thumbstick", L"Setting item to control whether left thumbstick should be enabled"), appSettings, AppSettingBooleanEntry::GamepadEnableLeftThumbstick, localSettings),
                 AppSettingsBooleanItem(LocalizationHelper::Localize(L"Enable Right Thumbstick", L"Setting item to control whether right thumbstick should be enabled"), appSettings, AppSettingBooleanEntry::GamepadEnableRightThumbstick, localSettings),
+                CelestiaWinUI::SettingGroupSeparator(),
                 AppSettingsBooleanItem(LocalizationHelper::Localize(L"Invert Horizontally", L"Invert game controller thumbstick axis horizontally"), appSettings, AppSettingBooleanEntry::GamepadInvertX, localSettings),
                 AppSettingsBooleanItem(LocalizationHelper::Localize(L"Invert Vertically", L"Invert game controller thumbstick axis vertically"), appSettings, AppSettingBooleanEntry::GamepadInvertY, localSettings),
             });
@@ -443,6 +460,7 @@ namespace winrt::CelestiaWinUI::implementation
 
     void SettingsUserControl::ItemGroupSelected(CelestiaWinUI::SettingsNavigationItemGroup const& itemGroup)
     {
+        PageTitle().Text(itemGroup.Title());
         SettingCommonUserControl userControl{ itemGroup.Items(), itemGroup.ShowRestartHint(), parameter };
         Container().Children().Clear();
         Container().Children().Append(userControl);

--- a/CelestiaWinUI/SettingsUserControl.xaml.h
+++ b/CelestiaWinUI/SettingsUserControl.xaml.h
@@ -33,8 +33,11 @@ namespace winrt::CelestiaWinUI::implementation
         void InitializeComponent();
 
         Windows::Foundation::Collections::IObservableVector<CelestiaWinUI::SettingsNavigationItemGroup> ItemGroups();
+        Microsoft::UI::Xaml::UIElement TitleBarElement();
 
         void NavigationView_SelectionChanged(Windows::Foundation::IInspectable const&, Microsoft::UI::Xaml::Controls::NavigationViewSelectionChangedEventArgs const& args);
+        void NavigationView_DisplayModeChanged(Microsoft::UI::Xaml::Controls::NavigationView const&, Microsoft::UI::Xaml::Controls::NavigationViewDisplayModeChangedEventArgs const& args);
+        void PaneToggleButton_Click(Windows::Foundation::IInspectable const&, Microsoft::UI::Xaml::RoutedEventArgs const&);
     private:
         Windows::Foundation::Collections::IObservableVector<CelestiaWinUI::SettingsNavigationItemGroup> itemGroups;
         CelestiaWinUI::SettingParameter parameter;

--- a/CelestiaWinUI/SettingsUserControl.xaml.h
+++ b/CelestiaWinUI/SettingsUserControl.xaml.h
@@ -16,13 +16,15 @@ namespace winrt::CelestiaWinUI::implementation
 {
     struct SettingsNavigationItemGroup : SettingsNavigationItemGroupT<SettingsNavigationItemGroup>
     {
-        SettingsNavigationItemGroup(hstring const& title, Windows::Foundation::Collections::IObservableVector<Windows::Foundation::IInspectable> const& items, bool showRestartHint);
+        SettingsNavigationItemGroup(hstring const& title, Microsoft::UI::Xaml::Controls::Symbol icon, Windows::Foundation::Collections::IObservableVector<Windows::Foundation::IInspectable> const& items, bool showRestartHint);
 
         hstring Title();
+        Microsoft::UI::Xaml::Controls::Symbol Icon();
         Windows::Foundation::Collections::IObservableVector<Windows::Foundation::IInspectable> Items();
         bool ShowRestartHint();
     private:
         hstring title;
+        Microsoft::UI::Xaml::Controls::Symbol icon;
         Windows::Foundation::Collections::IObservableVector<Windows::Foundation::IInspectable> items;
         bool showRestartHint;
     };


### PR DESCRIPTION
## Summary
- replace top-only settings navigation with an adaptive Windows-style navigation shell
- present related settings in connected card groups with semantic section and subgroup boundaries
- add responsive layouts, accessible control names, and incremental visibility updates

## Validation
- validated modified XAML documents
- checked the final diff for whitespace errors